### PR TITLE
Delete wireguard peer nico-hm90

### DIFF
--- a/env.nix
+++ b/env.nix
@@ -43,10 +43,6 @@
             publicKey = "PrSCG2vuAiHKnB3AJm1ii6T2LHaB8ZRu8GinjPGfXEc=";
             ip4 = "10.23.1.4";
           };
-          nico-hm90 = {
-            publicKey = "aMKMkLo92dHyvbB3vDde4kF9DQLGnw0NqocLGK4KcBA=";
-            ip4 = "10.23.1.5";
-          };
         };
       };
 

--- a/hosts/prod/secrets.yml
+++ b/hosts/prod/secrets.yml
@@ -8,7 +8,6 @@ wireguard:
         defelo: ENC[AES256_GCM,data:nDEHCzF8RKSrDJUPGdJpnKPN/Vwvk/hSvNaIcU/YOIqhd3ZoHgc2WkGvs5A=,iv:0/MP1atrmV1MNoRBCAcyBgjoSlrnavrI6fnn1rc3S+I=,tag:w2RyQNsVW4CttF9qOE18cw==,type:str]
         nico-p14s: ENC[AES256_GCM,data:Xwbkb742yHptqHyeTF8L7PD57mjgesAONyrG9KmneZXyEuDdpoVchqI7fPs=,iv:hDb8eLfAAiW1ln3uja2WVokeFiglGLcIFSBQAXkrC6w=,tag:963MUnsOZ1QaLsb0jqRqqQ==,type:str]
         nico-ws1: ENC[AES256_GCM,data:YXRasuTloqOjmX4jjdmjpCyQ5c/aUgCXFXAIYu+dUztYVdakzicAKf47wuw=,iv:qyQy5yliwqsnSKMIvc5Qc0M7mE8oNPLPT8sfOCvscYQ=,tag:fwvqZ5QFsIPf9sJWB5xdSQ==,type:str]
-        nico-hm90: ENC[AES256_GCM,data:WQRtEko3AW/Emkd2K48fucfunYsQpxlTacOJJ5+Lp6wpx54VBXLZhzwF1Fw=,iv:txxwy+w1PwizvEiGIBRRY6G84Bsh3h2IfdDLaOpnQEg=,tag:e5BdKQ/68UkCEYYUOuVnBg==,type:str]
 ssh:
     private-key: ENC[AES256_GCM,data:IL7hSrFt5Y0UCBomcaZDDm++Ce0uN5RAW18g0alNKq1/a9VzAN+LN7kjqv6l/eH9HGMwT+2xN3G/P8scqXluNMSNAGwACaOtZynbuwSQpV5IGPEcjUce9CnuIHhvXZhJ9H8VaZxf4CIMCQQetn8zEnRplEzu26Ei4Q2tlL56GqG22IqIE8KEsujpeICXqev2rZFSmRxLSVeVlsotzb+0kV5MiibMxte1GupWEP6NpeVm2VLw4eG7WQ9PJj+K66abD4GTTu8KaNC5ernZpfuvVD0ykTNL20pq8QnrQM5W5Afgv+ptrbNpHME6Jd49fYA+Igd3IUHXCnafYejrsnajK5j8PV1tIJllX2DnkKFrG3uk+Tjcuv0UkBCeryeB85Q3qLTS0rTcwAPNcvcoL1dHKEk9JlX6Q3g9R+V0DgBV+tVdlkqdwREjaP60jK2nvn4zlcwsnHtANIC4quvQhBmKITnDAeSTQpy8VSIFHqiMfFkUDNpMsKzQjFkwZ+C5VH8OR/RO,iv:LHKkh/Jn483z7qvsIAo6X1w3izFwARlCQ3eTW4Lhb2s=,tag:1By6J3RWnp6hFjJ41sgpJg==,type:str]
 glitchtip:
@@ -56,8 +55,8 @@ sops:
             OXAveVhHb2FxWG5SbFBBaHVFSjdEOXcKhAKda04jAAIL+L9VYy4bao6YG8QoXg7k
             MecsAb4KWC07QbrqtzSzcRuo3VpV25niZ28N0Bspee/TaXaagsiLXQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-02-29T18:06:02Z"
-    mac: ENC[AES256_GCM,data:93seKpdmliLmiTI/WIBtC0cPuZC611FSUf9rnPi9uF13D+FwYDWg7cMwmfEVdsjWWIN+G38ZdagjS07H5DES/l8jgFbHFSMlWwoReUA00vKUnPIipIWNhSgCL0a7etKB7cB72kU6elezbABUcdX6W4oMcc9bBlMUe+PDhXhWpVk=,iv:/TLbLIrEZbPNZp/aaUxCppk0FOTl9A0ncrCDYgTDJsU=,tag:gLsND03z1/U3USUOSF1FVA==,type:str]
+    lastmodified: "2024-06-08T23:47:11Z"
+    mac: ENC[AES256_GCM,data:go79WjMPOyayAhoRHGUc6leBSk7alFMaXafaeD+nMk2GRxmMOfAtALjQpfQuky3GQAh1KUWU9gvYVD2bRnw8IuAG3xVtqUw1XGAbCRR2fsbeQLQwRPFfpD/qgGsUijYGU3ld5Ap6CiMLQSK3BkJnFwaUiPPAdH5Up8tfa5Tljh8=,iv:CYOEtE18DEF5QDSAeD+oQKD9g/eWWPyNqETKfYCFsws=,tag:ijZO4YSv5sv8nT9H1WSlog==,type:str]
     pgp:
         - created_at: "2023-11-21T10:40:11Z"
           enc: |-


### PR DESCRIPTION
This wireguard peer is no longer required and should be deleted