### PR TITLE
Disable reCAPTCHA on the prod and test backend

### DIFF
--- a/hosts/prod/backend/default.nix
+++ b/hosts/prod/backend/default.nix
@@ -49,7 +49,7 @@
       };
 
       recaptcha = {
-        enable = true;
+        enable = false;
         sitekey = "6Le9pMIiAAAAAAMmaH3J7ZCsQk6JcBdQtAJNXaQJ";
         min_score = 0.5;
       };
@@ -96,8 +96,8 @@
 
         INTERNAL_JWT_TTL = "10";
 
-        RECAPTCHA_SITEKEY = "6Le9pMIiAAAAAAMmaH3J7ZCsQk6JcBdQtAJNXaQJ";
-        RECAPTCHA_MIN_SCORE = "0.5";
+        # RECAPTCHA_SITEKEY = "6Le9pMIiAAAAAAMmaH3J7ZCsQk6JcBdQtAJNXaQJ";
+        # RECAPTCHA_MIN_SCORE = "0.5";
 
         SMTP_HOST = "mail.your-server.de";
         SMTP_PORT = "587";

--- a/hosts/test/backend/default.nix
+++ b/hosts/test/backend/default.nix
@@ -53,7 +53,7 @@
       };
 
       recaptcha = {
-        enable = true;
+        enable = false;
         sitekey = "6Ldb070iAAAAAKsAt_M_ilgDbnWcF-N_Pj2DBBeP";
         min_score = 0.5;
       };


### PR DESCRIPTION
Turns Google reCAPTCHA off in the backend configuration of both hosts.

## What changes

- `hosts/prod/backend/default.nix` and `hosts/test/backend/default.nix`: `services.academy.backend.settings.recaptcha.enable` `true` → `false`.
- `hosts/prod/backend/default.nix`: comments out the leftover `RECAPTCHA_SITEKEY` / `RECAPTCHA_MIN_SCORE` environment variables of the legacy Python services, matching what `hosts/test` already does. `RECAPTCHA_SECRET` was already commented out on both hosts, so those services could not verify a token anyway.

## What deliberately stays

- `sitekey` and `min_score` in the `recaptcha` block. `RecaptchaConfig` is deserialised before the `enable` flag is evaluated and declares `sitekey` and `secret` as required fields, so dropping them would stop the backend from starting.
- The sops secret `academy-backend/recaptcha-secret` and its `sops.templates."academy-backend/config"` line, for the same reason.

Removing the block entirely would not work either: the compiled-in default in the backend's `config.toml` is `enable = true`, so the flag has to be set explicitly.

## Deployment

This repository has no automatic deployment — `.github/workflows/nix.yml` only runs `nix fmt --ci` and `nix build .#checks`, which builds the host closures without activating them. Applying this change to prod and test needs a human to run `deploy` from the dev shell over WireGuard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)