### PR TITLE
chore: bound log, backup and error report retention

### DIFF
--- a/hosts/prod/glitchtip.nix
+++ b/hosts/prod/glitchtip.nix
@@ -26,6 +26,8 @@ in
       DEFAULT_FROM_EMAIL = "glitchtip@the-morpheus.de";
       ENABLE_USER_REGISTRATION = false;
       ENABLE_ORGANIZATION_CREATION = false;
+      # Error reports are deleted after 90 days, as stated in the privacy notice.
+      GLITCHTIP_RETENTION_DAYS = 90;
       GLITCHTIP_UPTIME_ALLOW_PRIVATE_IPS = true;
     };
   };

--- a/hosts/prod/nginx.nix
+++ b/hosts/prod/nginx.nix
@@ -18,6 +18,9 @@
     virtualHosts."sandkasten.bootstrap.academy" = {
       forceSSL = true;
       enableACME = true;
+      # The code execution service is only called by challenges-ms over the
+      # internal network.
+      allow = env.wg.admins ++ [ env.net.hosts ];
       extraConfig = ''
         limit_req zone=sandkasten_public burst=5 nodelay;
         limit_req_status 429;

--- a/hosts/prod/restic.nix
+++ b/hosts/prod/restic.nix
@@ -5,36 +5,47 @@ let
     "test"
   ];
 
+  # Snapshots older than these limits are deleted on every backup target, as
+  # stated in the privacy notice.
   prunePolicy = [
     "--keep-hourly 48"
     "--keep-daily 14"
     "--keep-weekly 8"
-    "--keep-monthly 24"
-    "--keep-yearly unlimited"
+    "--keep-monthly 12"
   ];
+
+  prune = {
+    timerConfig = {
+      OnCalendar = "04:20";
+      Persistent = true;
+    };
+
+    initialize = true;
+
+    pruneOpts = prunePolicy;
+  };
 in
 {
-  services.restic.backups = builtins.listToAttrs (
-    map (repo: {
-      name = "box-${repo}";
-      value = {
-        timerConfig = {
-          OnCalendar = "04:20";
-          Persistent = true;
+  services.restic.backups =
+    builtins.listToAttrs (
+      map (repo: {
+        name = "box-${repo}";
+        value = prune // {
+          repository = "sftp://u381435@u381435.your-storagebox.de:23/backups/${repo}";
+          passwordFile = config.sops.secrets."restic/${repo}".path;
+          extraOptions = [ "sftp.args='-i ${config.sops.secrets."ssh/private-key".path}'" ];
+
+          runCheck = true;
+          checkOpts = [ "--read-data-subset=4G" ];
         };
-        repository = "sftp://u381435@u381435.your-storagebox.de:23/backups/${repo}";
-        passwordFile = config.sops.secrets."restic/${repo}".path;
-        extraOptions = [ "sftp.args='-i ${config.sops.secrets."ssh/private-key".path}'" ];
-
-        initialize = true;
-
-        pruneOpts = prunePolicy;
-
-        runCheck = true;
-        checkOpts = [ "--read-data-subset=4G" ];
+      }) repos
+    )
+    // {
+      defelo-prod = prune // {
+        inherit (config.backup.targets.defelo) repository environmentFile;
+        passwordFile = config.backup.targets.defelo.repositoryPasswordFile;
       };
-    }) repos
-  );
+    };
 
   sops.secrets = builtins.listToAttrs (map (repo: lib.nameValuePair "restic/${repo}" { }) repos);
 }

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -8,6 +8,7 @@
     ./containers.nix
     ./deploy.nix
     ./filesystems.nix
+    ./logging.nix
     ./monitoring.nix
     ./networking.nix
     ./nginx.nix

--- a/modules/logging.nix
+++ b/modules/logging.nix
@@ -1,0 +1,23 @@
+{ config, lib, ... }:
+
+let
+  # Server logs are deleted after 30 days, as stated in the privacy notice.
+  retentionDays = 30;
+in
+
+{
+  services.journald.extraConfig = ''
+    MaxRetentionSec=${toString retentionDays}day
+    SystemMaxUse=1G
+  '';
+
+  # nginx writes its error log to stderr and therefore to the journal; only the
+  # access logs are rotated by logrotate.
+  services.logrotate.settings = lib.mkIf config.services.nginx.enable {
+    nginx = {
+      frequency = "daily";
+      rotate = retentionDays;
+      maxage = retentionDays;
+    };
+  };
+}


### PR DESCRIPTION
Bounds how long operational data is kept and closes public access to the code execution service.

**Log rotation** (new `modules/logging.nix`, imported by every host)
- journald: `MaxRetentionSec=30day`, `SystemMaxUse=1G` (previously unbounded in time).
- nginx access logs (`access.log`, `prometheus.log`): rotated daily, `rotate 30` + `maxage 30` instead of the nixpkgs default of weekly × 26 (≈ 6 months). nginx logs its errors to stderr, so the error log is in the journal and covered by the journald cap.

**Backup pruning** (`hosts/prod/restic.nix`)
- Policy is now `--keep-hourly 48 --keep-daily 14 --keep-weekly 8 --keep-monthly 12`; `--keep-monthly 24` and `--keep-yearly unlimited` are gone, so a snapshot lives at most about a year.
- The same policy now also runs against the REST target (`defelo-prod`), which had no prune options at all and therefore kept every hourly snapshot forever. The first run will take a while.
- The hourly backup cadence and the daily check of the Storage Box repositories are unchanged.

**Error tracking** (`hosts/prod/glitchtip.nix`)
- `GLITCHTIP_RETENTION_DAYS = 90` is now pinned explicitly instead of relying on the product default.

**Sandbox vhost** (`hosts/prod/nginx.nix`)
- `sandkasten.bootstrap.academy` was a public, unauthenticated vhost. It is now restricted to the internal network and the admin VPN with the same `allow`/`deny` pattern as the Grafana and GlitchTip vhosts; anonymous clients get 403, including on `/docs`. challenges-ms talks to the service over the internal address (`hosts/prod/backend/challenges.nix`), and nothing in the frontend calls the public hostname, so nothing that works today stops working. ACME renewal is unaffected: the challenge location lives in the port 80 server block, which carries no access rules.

Verified locally: `nix fmt -- --ci` clean, all three host configurations evaluate, and the generated `journald.conf`, `logrotate.conf`, GlitchTip environment, restic jobs and nginx server blocks contain the values above. Nothing is deployed by merging this; the prod, test and sandkasten hosts need a manual `deploy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
