### PR TITLE
Bump challenges-ms

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -122,11 +122,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1738680804,
-        "narHash": "sha256-9fOG4V4F6y9UOrh6JVDavp+gsiLY4xMIY/CLEH89Odg=",
+        "lastModified": 1788428096,
+        "narHash": "sha256-D5gx02Zs3F/uTLHgrjJf+8FDeR6w0mxXo9rSCx5Lq8Y=",
         "owner": "Bootstrap-Academy",
         "repo": "challenges-ms",
-        "rev": "d9280c8486bc8dd35f69aa8185df289e1d2a58a1",
+        "rev": "16f8250c17c71b7eefb1d11518afc900e44bbca3",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1738680804,
-        "narHash": "sha256-9fOG4V4F6y9UOrh6JVDavp+gsiLY4xMIY/CLEH89Odg=",
+        "lastModified": 1788428096,
+        "narHash": "sha256-D5gx02Zs3F/uTLHgrjJf+8FDeR6w0mxXo9rSCx5Lq8Y=",
         "owner": "Bootstrap-Academy",
         "repo": "challenges-ms",
-        "rev": "d9280c8486bc8dd35f69aa8185df289e1d2a58a1",
+        "rev": "16f8250c17c71b7eefb1d11518afc900e44bbca3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Bumps the `challenges-ms` flake input from `d9280c8` to `16f8250`, picking up
[Bootstrap-Academy/challenges-ms#315](https://github.com/Bootstrap-Academy/challenges-ms/pull/315).

The auth service returns `avatar_url: null` for every user now. challenges-ms
used to deserialize that field as a plain `String`, so it failed to parse the
internal user info and every `/challenges/leaderboard*` endpoint returned 500.
The bumped revision treats the field as optional.

`challenges-ms-develop`, which the `test` host imports, is moved to the same
commit for the same reason. No other input changes.

## Deployment

Deploys are manual — `prod` picks this up on the next `deploy` run. The
challenges microservice tolerates both the old and the new auth response, so
it can be deployed before or together with the backend, but not after.

Co-Authored-By: Claude <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
