### PR TITLE
chore: bump skills-ms and skills-ms-develop

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1908,11 +1908,11 @@
         "poetry2nix": "poetry2nix_5"
       },
       "locked": {
-        "lastModified": 1746543356,
-        "narHash": "sha256-zI9qmeySr9S0bImWhga/XtmJb5Y8+v+8wOI8QL0f6F8=",
+        "lastModified": 1788437545,
+        "narHash": "sha256-F5UGuNgqd/fi2Qp3ASMX/N2Tz6+Vkeb3r5c77dLVNXo=",
         "owner": "Bootstrap-Academy",
         "repo": "skills-ms",
-        "rev": "951b5092a3bdfc4c688be73f7e71a6523efa2e02",
+        "rev": "af385ef54beee31cf74e3a5f92d01bc59fd8e147",
         "type": "github"
       },
       "original": {
@@ -1928,11 +1928,11 @@
         "poetry2nix": "poetry2nix_6"
       },
       "locked": {
-        "lastModified": 1746543356,
-        "narHash": "sha256-zI9qmeySr9S0bImWhga/XtmJb5Y8+v+8wOI8QL0f6F8=",
+        "lastModified": 1788437545,
+        "narHash": "sha256-F5UGuNgqd/fi2Qp3ASMX/N2Tz6+Vkeb3r5c77dLVNXo=",
         "owner": "Bootstrap-Academy",
         "repo": "skills-ms",
-        "rev": "951b5092a3bdfc4c688be73f7e71a6523efa2e02",
+        "rev": "af385ef54beee31cf74e3a5f92d01bc59fd8e147",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps the `skills-ms` and `skills-ms-develop` inputs from `951b509` (2025-05-06)
to `af385ef`.

Both inputs were far behind, so the bump also picks up `b4695c9`, which deletes
a user's data in skills-ms when the account is deleted. The new commit,
`af385ef`, makes the course lists honour premium: `GET /skills/course_access`
and `GET /skills/courses?owned=true` now return the courses a premium member or
an admin can open, not only the ones they bought — the single-course check
already worked that way.

`latest` and `develop` point at the same commit, so both inputs move together.

Deploying stays a manual step; this only moves the pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
