### PR TITLE
chore: propagate account deletion to the microservices

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1787709911,
-        "narHash": "sha256-Z9FJlSqaFiV/V2W0XkpNovocNRKoqoyuGZY7RKo0g7I=",
+        "lastModified": 1788437548,
+        "narHash": "sha256-pkbz8ISR+/1MvaTxzwBjbLeNYbR2CgQmDXy83pHAQak=",
         "owner": "Bootstrap-Academy",
         "repo": "backend",
-        "rev": "2a704154e33bba84c05183f430e4870e47906d8c",
+        "rev": "f16da9b8f048f504488c3dbe9cca9384579f11ee",
         "type": "github"
       },
       "original": {
@@ -28,11 +28,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1787709911,
-        "narHash": "sha256-Z9FJlSqaFiV/V2W0XkpNovocNRKoqoyuGZY7RKo0g7I=",
+        "lastModified": 1788437548,
+        "narHash": "sha256-pkbz8ISR+/1MvaTxzwBjbLeNYbR2CgQmDXy83pHAQak=",
         "owner": "Bootstrap-Academy",
         "repo": "backend",
-        "rev": "2a704154e33bba84c05183f430e4870e47906d8c",
+        "rev": "f16da9b8f048f504488c3dbe9cca9384579f11ee",
         "type": "github"
       },
       "original": {
@@ -122,11 +122,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1788428096,
-        "narHash": "sha256-D5gx02Zs3F/uTLHgrjJf+8FDeR6w0mxXo9rSCx5Lq8Y=",
+        "lastModified": 1788436563,
+        "narHash": "sha256-btmMoiwUF2YrCUCmwbSDRnBdhYm4P06oiPmtjDG1saY=",
         "owner": "Bootstrap-Academy",
         "repo": "challenges-ms",
-        "rev": "16f8250c17c71b7eefb1d11518afc900e44bbca3",
+        "rev": "52eefe3e905aab74e7d0b695bbbbd93acc0751e7",
         "type": "github"
       },
       "original": {
@@ -142,11 +142,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1788428096,
-        "narHash": "sha256-D5gx02Zs3F/uTLHgrjJf+8FDeR6w0mxXo9rSCx5Lq8Y=",
+        "lastModified": 1788436563,
+        "narHash": "sha256-btmMoiwUF2YrCUCmwbSDRnBdhYm4P06oiPmtjDG1saY=",
         "owner": "Bootstrap-Academy",
         "repo": "challenges-ms",
-        "rev": "16f8250c17c71b7eefb1d11518afc900e44bbca3",
+        "rev": "52eefe3e905aab74e7d0b695bbbbd93acc0751e7",
         "type": "github"
       },
       "original": {
@@ -307,11 +307,11 @@
         "poetry2nix": "poetry2nix"
       },
       "locked": {
-        "lastModified": 1788437070,
-        "narHash": "sha256-JK9HCee96Y4fvsL5tyXfzPpezIlwzB1ZzGJ7Z2dNGm8=",
+        "lastModified": 1788437496,
+        "narHash": "sha256-OHs9RcNpd/MDL4rQ3nWDEwQAG0n8LK0ZyyQDdZV0qXg=",
         "owner": "Bootstrap-Academy",
         "repo": "events-ms",
-        "rev": "2f3f42592f7f98444875c3f5b80c65370fc584a3",
+        "rev": "f46160c6f47c2f7f5ab23018cb473db106d365a2",
         "type": "github"
       },
       "original": {
@@ -1908,11 +1908,11 @@
         "poetry2nix": "poetry2nix_5"
       },
       "locked": {
-        "lastModified": 1746543356,
-        "narHash": "sha256-zI9qmeySr9S0bImWhga/XtmJb5Y8+v+8wOI8QL0f6F8=",
+        "lastModified": 1788437545,
+        "narHash": "sha256-F5UGuNgqd/fi2Qp3ASMX/N2Tz6+Vkeb3r5c77dLVNXo=",
         "owner": "Bootstrap-Academy",
         "repo": "skills-ms",
-        "rev": "951b5092a3bdfc4c688be73f7e71a6523efa2e02",
+        "rev": "af385ef54beee31cf74e3a5f92d01bc59fd8e147",
         "type": "github"
       },
       "original": {
@@ -1928,11 +1928,11 @@
         "poetry2nix": "poetry2nix_6"
       },
       "locked": {
-        "lastModified": 1746543356,
-        "narHash": "sha256-zI9qmeySr9S0bImWhga/XtmJb5Y8+v+8wOI8QL0f6F8=",
+        "lastModified": 1788437545,
+        "narHash": "sha256-F5UGuNgqd/fi2Qp3ASMX/N2Tz6+Vkeb3r5c77dLVNXo=",
         "owner": "Bootstrap-Academy",
         "repo": "skills-ms",
-        "rev": "951b5092a3bdfc4c688be73f7e71a6523efa2e02",
+        "rev": "af385ef54beee31cf74e3a5f92d01bc59fd8e147",
         "type": "github"
       },
       "original": {

--- a/hosts/prod/backend/challenges.nix
+++ b/hosts/prod/backend/challenges.nix
@@ -15,6 +15,10 @@
 
   academy.backend.challenges = {
     enable = true;
+    sweepDeletedUsers = {
+      enable = true;
+      interval = "03:40";
+    };
     RUST_LOG = "info";
     environmentFiles = [
       config.sops.templates."academy-backend/common".path

--- a/hosts/prod/backend/default.nix
+++ b/hosts/prod/backend/default.nix
@@ -44,6 +44,13 @@
         email_cache_ttl = "5m";
       };
 
+      microservices = {
+        skills_url = "http://127.0.0.1:${toString config.academy.backend.microservices.skills.port}/";
+        challenges_url = "http://127.0.0.1:${toString config.academy.backend.microservices.challenges.port}/";
+        events_url = "http://127.0.0.1:${toString config.academy.backend.microservices.events.port}/";
+        timeout = "10s";
+      };
+
       contact = {
         email = "hallo@bootstrap.academy";
       };

--- a/hosts/prod/backend/events.nix
+++ b/hosts/prod/backend/events.nix
@@ -18,6 +18,10 @@ in
 
   academy.backend.events = {
     enable = true;
+    sweepDeletedUsers = {
+      enable = true;
+      interval = "03:25";
+    };
     environmentFiles = config.academy.backend.common.environmentFiles ++ [
       config.sops.templates."academy-backend/events-ms".path
     ];

--- a/hosts/prod/backend/skills.nix
+++ b/hosts/prod/backend/skills.nix
@@ -21,6 +21,10 @@ in
 
   academy.backend.skills = {
     enable = true;
+    sweepDeletedUsers = {
+      enable = true;
+      interval = "03:10";
+    };
     environmentFiles = config.academy.backend.common.environmentFiles ++ [
       config.sops.templates."academy-backend/skills-ms".path
     ];

--- a/hosts/test/backend/challenges.nix
+++ b/hosts/test/backend/challenges.nix
@@ -16,6 +16,10 @@
 
   academy.backend.challenges = {
     enable = true;
+    sweepDeletedUsers = {
+      enable = true;
+      interval = "03:40";
+    };
     RUST_LOG = "info,poem_ext,lib,entity,migration,challenges=trace";
     environmentFiles = [
       config.sops.templates."academy-backend/common".path

--- a/hosts/test/backend/default.nix
+++ b/hosts/test/backend/default.nix
@@ -41,6 +41,13 @@
         email_cache_ttl = "5m";
       };
 
+      microservices = {
+        skills_url = "http://127.0.0.1:${toString config.academy.backend.microservices.skills.port}/";
+        challenges_url = "http://127.0.0.1:${toString config.academy.backend.microservices.challenges.port}/";
+        events_url = "http://127.0.0.1:${toString config.academy.backend.microservices.events.port}/";
+        timeout = "10s";
+      };
+
       user = {
         name_change_rate_limit = "1d";
         verification_redirect_url = "https://test.bootstrap.academy/auth/verify-account";

--- a/hosts/test/backend/events.nix
+++ b/hosts/test/backend/events.nix
@@ -18,6 +18,10 @@ in
 
   academy.backend.events = {
     enable = true;
+    sweepDeletedUsers = {
+      enable = true;
+      interval = "03:25";
+    };
     environmentFiles = config.academy.backend.common.environmentFiles ++ [
       config.sops.templates."academy-backend/events-ms".path
     ];

--- a/hosts/test/backend/skills.nix
+++ b/hosts/test/backend/skills.nix
@@ -21,6 +21,10 @@ in
 
   academy.backend.skills = {
     enable = true;
+    sweepDeletedUsers = {
+      enable = true;
+      interval = "03:10";
+    };
     environmentFiles = config.academy.backend.common.environmentFiles ++ [
       config.sops.templates."academy-backend/skills-ms".path
     ];


### PR DESCRIPTION
Wires up the cross-service account deletion that landed in the four service repos today.

### Backend → microservices

`services.academy.backend.settings.microservices` on **prod** and **test**:

| key | value |
|---|---|
| `skills_url` | `http://127.0.0.1:8001/` |
| `challenges_url` | `http://127.0.0.1:8005/` |
| `events_url` | `http://127.0.0.1:8004/` |
| `timeout` | `10s` (per request) |

The ports come from `config.academy.backend.microservices.<ms>.port`, so they cannot drift from the service definitions. When a user deletes their account, the backend now also calls `DELETE <url>_internal/users/<id>` on each of the three services, concurrently, with an internal JWT carrying the service's audience. Failures are logged and swallowed — a service being down never fails the user's request.

### Nightly sweep

`academy.backend.{skills,events,challenges}.sweepDeletedUsers.enable = true` on both hosts, staggered so they do not hit the auth service at the same time:

| unit | `OnCalendar` |
|---|---|
| `academy-skills-sweep-deleted-users` | `03:10` |
| `academy-events-sweep-deleted-users` | `03:25` |
| `academy-challenges-sweep-deleted-users` | `03:40` |

All three have `RandomizedDelaySec = 5m` and `Persistent = true` from the module defaults. Each oneshot unit runs as the same (dynamic) user as its service, so it reaches its own database over the same peer-authenticated socket. The sweep walks the distinct user ids in its database in batches, asks the auth service whether each still exists (rate-limited, 10 req/s by default), and deletes the rows of the ones that no longer do. It is the safety net for a fan-out call that failed, and it also clears out rows left behind by accounts deleted before today.

### `flake.lock`

| input | new rev |
|---|---|
| `skills-ms` / `skills-ms-develop` | `af385ef` |
| `events-ms` | `f46160c` |
| `challenges-ms` / `challenges-ms-develop` | `52eefe3` |
| `backend` / `backend-develop` | `f16da9b` |

`events-ms-develop` was already current at `f48db6a`.

**The backend bump also releases four other changes** already merged into `develop`: #718 (recaptcha_response optional in the OpenAPI schema), #719 (terms acceptance and age confirmation on signup), #720 (stop deriving avatar URLs from e-mail addresses) and #721 (expose the Morphcoin rate and VAT percentage). The `skills-ms` bump also carries #400 (courses unlocked by premium in the course lists).

### Verified

`nix fmt --ci` clean; both `prod` and `test` evaluate, with the timers, the oneshot units (correct user, environment files and `CONFIG_PATH`) and the rendered backend `[microservices]` section checked by hand.

Merging this deploys nothing — `deploy` is still manual. Suggested order: `deploy test`, then `deploy prod`. Within a host the services come up before the backend, and the backend's fan-out is inert until this config reaches it, so there is no ordering hazard either way.
