### PR TITLE
chore(test): drop the removed newsletter backend config key

### DIFF
--- a/hosts/test/backend/default.nix
+++ b/hosts/test/backend/default.nix
@@ -52,7 +52,6 @@
         name_change_rate_limit = "1d";
         verification_redirect_url = "https://test.bootstrap.academy/auth/verify-account";
         password_reset_redirect_url = "https://test.bootstrap.academy/auth/reset-password";
-        newsletter_redirect_url = "https://test.bootstrap.academy/account/newsletter";
       };
 
       contact = {


### PR DESCRIPTION
The backend no longer defines `user.newsletter_redirect_url` (backend #725), so the override in the test host's backend config points at a config key that no longer exists.

Config parsing ignores unknown keys, so nothing breaks either way and this can be merged in any order relative to the backend change. Deploys stay manual.

Co-Authored-By: Claude <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
