### PR TITLE
chore: bump the backend and jobs-ms inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1788448928,
-        "narHash": "sha256-qpcTKCMarzoeLl2f7dJlXTA3p7tADdIdiUpaqcUliaY=",
+        "lastModified": 1788451721,
+        "narHash": "sha256-RT7x70oCn9KTGH3h3U8u6jYKMjFOovs9cXfrirKFUlw=",
         "owner": "Bootstrap-Academy",
         "repo": "backend",
-        "rev": "3a17b69264b39bc44ca384d0c0606ed6f2b0f1b3",
+        "rev": "f0e5ed670e346e5eb05a473c580d238f68fd7294",
         "type": "github"
       },
       "original": {
@@ -28,11 +28,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1788448928,
-        "narHash": "sha256-qpcTKCMarzoeLl2f7dJlXTA3p7tADdIdiUpaqcUliaY=",
+        "lastModified": 1788451721,
+        "narHash": "sha256-RT7x70oCn9KTGH3h3U8u6jYKMjFOovs9cXfrirKFUlw=",
         "owner": "Bootstrap-Academy",
         "repo": "backend",
-        "rev": "3a17b69264b39bc44ca384d0c0606ed6f2b0f1b3",
+        "rev": "f0e5ed670e346e5eb05a473c580d238f68fd7294",
         "type": "github"
       },
       "original": {
@@ -801,11 +801,11 @@
         "poetry2nix": "poetry2nix_4"
       },
       "locked": {
-        "lastModified": 1788435979,
-        "narHash": "sha256-hcWBZvokDwMela8Iyt4tR3QjDpI2sweDcvZ1i7lzyXw=",
+        "lastModified": 1788452562,
+        "narHash": "sha256-6N8om/9dfWblG8sLXZI9caThPx1eLUphR8Bt7IPjKTM=",
         "owner": "Bootstrap-Academy",
         "repo": "jobs-ms",
-        "rev": "2420dc60fd4917f4667963cc7b050b5e44fa72b0",
+        "rev": "60cf9804ec8dbf68fd59e1a3b27f7ae2e129b2d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Final consolidation of the Bootstrap Academy service inputs before the manual `deploy`.

| input | ref it follows | old rev | new rev |
| --- | --- | --- | --- |
| `backend` | `develop` | `3a17b69` | `f0e5ed6` |
| `backend-develop` | `develop` | `3a17b69` | `f0e5ed6` |
| `jobs-ms-develop` | `develop` | `2420dc6` | `60cf980` |
| `challenges-ms` / `challenges-ms-develop` | `latest` / `develop` | `52eefe3` | unchanged, already at head |
| `events-ms` / `events-ms-develop` | `latest` / `develop` | `fece9e1` / `a8a1a8a` | unchanged, already at head |
| `jobs-ms` | `latest` | `eb89be9` | unchanged, already at head |
| `skills-ms` / `skills-ms-develop` | `latest` / `develop` | `0483369` | unchanged, already at head |

`backend` f0e5ed6 is backend#727 on top of the head this repo already
pinned, so the only new backend commit is the dismissible terms gate and
the recorded refusal. `jobs-ms-develop` 60cf980 is jobs-ms#205, a
one-line CI fix (`cachix/install-nix-action@V27` -> `@v27`); it is the
first jobs-ms `develop` commit whose `build (x86_64-linux)` job has
actually run since that tag was introduced.

`sandkasten` is deliberately left at `ee8d9b0`. Upstream has moved two
commits ahead (`chore: update dependencies` + `chore: update
flake.lock`); both are unrelated dependency bumps and pulling them in
would rebuild the sandbox host and all of its language environments
during a release that is otherwise scoped to the backend.

No module or host changes.

Co-Authored-By: Claude <noreply@anthropic.com>