### PR TITLE
Document retention, the cleanup timers and the sandbox exposure

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,41 @@ To connect to the database, run the postgres administration commands as the `pos
 
 ### Redis
 To connect to redis, run the `redis-cli` command.
+
+## Retention
+
+### Logs
+`modules/logging.nix` is imported by `modules/default.nix` and therefore applies to every host.
+It keeps journald entries for 30 days (`MaxRetentionSec=30day`, capped at `SystemMaxUse=1G`) and rotates the nginx access logs daily, keeping 30 rotations and dropping anything older than 30 days.
+The nginx error log is written to stderr and ends up in the journal, so it is covered by the journald setting.
+
+### Backups
+`hosts/prod/restic.nix` defines the jobs that apply the retention policy to the three repositories the `prod` host is responsible for: `box-prod` and `box-test` on the Storage Box and `defelo-prod` on the REST target.
+All three run daily at 04:20 and use the same policy:
+
+```
+--keep-hourly 48 --keep-daily 14 --keep-weekly 8 --keep-monthly 12
+```
+
+The backups themselves are taken by `modules/backup.nix`, which snapshots `/persistent/data` and pushes it to every target in `backup.targets` on the `backup.schedule` (hourly by default).
+
+### Error reports
+`hosts/prod/glitchtip.nix` pins `GLITCHTIP_RETENTION_DAYS = 90`, so GlitchTip deletes events after 90 days.
+
+## Scheduled Cleanups
+The microservices delete the data of accounts that no longer exist in the backend.
+The deletion is propagated by the backend when an account is deleted; the timers below are the safety net for the calls that could not be delivered.
+They are enabled on both `prod` and `test`:
+
+| Service | Option | Time |
+| --- | --- | --- |
+| skills-ms | `academy.backend.skills.sweepDeletedUsers` | 03:10 |
+| events-ms | `academy.backend.events.sweepDeletedUsers` | 03:25 |
+| challenges-ms | `academy.backend.challenges.sweepDeletedUsers` | 03:40 |
+
+The backend has its own timers (`services.academy.backend.tasks.<task>.schedule`), which its NixOS module defaults to hourly for `prune-database` and daily for `refresh-premium`.
+
+## Sandbox Exposure
+`sandkasten.bootstrap.academy` (`hosts/prod/nginx.nix`) proxies the code execution service, which is only meant to be called by challenges-ms over the internal network.
+The vhost is therefore restricted with `allow = env.wg.admins ++ [ env.net.hosts ]`; every other client gets a `403`, including on `/docs`.
+Requests that do not come from the WireGuard network are additionally rate limited to 20 requests per minute with a burst of 5 (`429` beyond that), and `/metrics` returns `403` for everyone.


### PR DESCRIPTION
Documentation only, no configuration changes.

New README sections:

- **Retention** — the shared `modules/logging.nix` (journald 30 days, nginx access log rotation), the restic prune policy in `hosts/prod/restic.nix` and which repositories it covers, and the GlitchTip event retention.
- **Scheduled Cleanups** — the `sweepDeletedUsers` timers of the three microservices with their times, plus a pointer to the backend task timers.
- **Sandbox Exposure** — the access rule and rate limit on the `sandkasten.bootstrap.academy` vhost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)