### PR TITLE
Per-audience secrets for the internal service tokens, and the service input bump

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1788451721,
-        "narHash": "sha256-RT7x70oCn9KTGH3h3U8u6jYKMjFOovs9cXfrirKFUlw=",
+        "lastModified": 1788709302,
+        "narHash": "sha256-wVQoN19JAZdNnjfBFVYsUM+VLOdo5uiVdiEH+cZ34KI=",
         "owner": "Bootstrap-Academy",
         "repo": "backend",
-        "rev": "f0e5ed670e346e5eb05a473c580d238f68fd7294",
+        "rev": "63fcc42feaa52b63e7964c3b7dd752714abe2048",
         "type": "github"
       },
       "original": {
@@ -28,11 +28,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1788451721,
-        "narHash": "sha256-RT7x70oCn9KTGH3h3U8u6jYKMjFOovs9cXfrirKFUlw=",
+        "lastModified": 1788709302,
+        "narHash": "sha256-wVQoN19JAZdNnjfBFVYsUM+VLOdo5uiVdiEH+cZ34KI=",
         "owner": "Bootstrap-Academy",
         "repo": "backend",
-        "rev": "f0e5ed670e346e5eb05a473c580d238f68fd7294",
+        "rev": "63fcc42feaa52b63e7964c3b7dd752714abe2048",
         "type": "github"
       },
       "original": {
@@ -122,11 +122,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1788436563,
-        "narHash": "sha256-btmMoiwUF2YrCUCmwbSDRnBdhYm4P06oiPmtjDG1saY=",
+        "lastModified": 1788710581,
+        "narHash": "sha256-4e89Rkc2OxMXxaxZaTxy812W3tBmU5VaNcPPrPLn+Oo=",
         "owner": "Bootstrap-Academy",
         "repo": "challenges-ms",
-        "rev": "52eefe3e905aab74e7d0b695bbbbd93acc0751e7",
+        "rev": "6c7a2393e69d8aceaa3a1ff66b46d867cbaf0f75",
         "type": "github"
       },
       "original": {
@@ -142,11 +142,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1788436563,
-        "narHash": "sha256-btmMoiwUF2YrCUCmwbSDRnBdhYm4P06oiPmtjDG1saY=",
+        "lastModified": 1788710463,
+        "narHash": "sha256-4e89Rkc2OxMXxaxZaTxy812W3tBmU5VaNcPPrPLn+Oo=",
         "owner": "Bootstrap-Academy",
         "repo": "challenges-ms",
-        "rev": "52eefe3e905aab74e7d0b695bbbbd93acc0751e7",
+        "rev": "1bd346b750fecc5b3b9545e6334d41119f143c10",
         "type": "github"
       },
       "original": {
@@ -307,11 +307,11 @@
         "poetry2nix": "poetry2nix"
       },
       "locked": {
-        "lastModified": 1788448802,
-        "narHash": "sha256-d3Gaw+lzVLBs8cvvPTZ0acPnti8AZhUolfB65Nl2v58=",
+        "lastModified": 1788711050,
+        "narHash": "sha256-IxsdhmV4KM5CfyvUoBtdXWyTRcbrtgwzs5ukQB3Nbr0=",
         "owner": "Bootstrap-Academy",
         "repo": "events-ms",
-        "rev": "fece9e161c9221f0061ccf6901c9a53097b0e47a",
+        "rev": "cdbe3c4e1c54225b3a1d69b2e8337ba75f04a906",
         "type": "github"
       },
       "original": {
@@ -327,11 +327,11 @@
         "poetry2nix": "poetry2nix_2"
       },
       "locked": {
-        "lastModified": 1788448633,
-        "narHash": "sha256-d3Gaw+lzVLBs8cvvPTZ0acPnti8AZhUolfB65Nl2v58=",
+        "lastModified": 1788461548,
+        "narHash": "sha256-lYgkRaO596Mt/Ni1Gp14tGqienS7soQWOYEybCZF8Mc=",
         "owner": "Bootstrap-Academy",
         "repo": "events-ms",
-        "rev": "a8a1a8acefb67d0de749b1076af746d0c53f737e",
+        "rev": "3994f4b1765a22085f6c3809e05b9d4265e95c29",
         "type": "github"
       },
       "original": {
@@ -781,11 +781,11 @@
         "poetry2nix": "poetry2nix_3"
       },
       "locked": {
-        "lastModified": 1788437075,
-        "narHash": "sha256-cIUZc23yprVdpLsdHFhAn46DL1//vaVS+bPRaNLSAkY=",
+        "lastModified": 1788461504,
+        "narHash": "sha256-fU9/xu8tNM5TLrxORrqdQZwQlqYMz5dJZWMfY+7Fuj8=",
         "owner": "Bootstrap-Academy",
         "repo": "jobs-ms",
-        "rev": "eb89be99ff3ae4881639397ebb74460037b18c68",
+        "rev": "f93cc6bacea4d77ba77c0fcdecff1c3633a23c1e",
         "type": "github"
       },
       "original": {
@@ -801,11 +801,11 @@
         "poetry2nix": "poetry2nix_4"
       },
       "locked": {
-        "lastModified": 1788452562,
-        "narHash": "sha256-6N8om/9dfWblG8sLXZI9caThPx1eLUphR8Bt7IPjKTM=",
+        "lastModified": 1788461149,
+        "narHash": "sha256-0O2datsOLoXRfGzFMMRSJuj7B5OaGyQwrCGd/kLCjaU=",
         "owner": "Bootstrap-Academy",
         "repo": "jobs-ms",
-        "rev": "60cf9804ec8dbf68fd59e1a3b27f7ae2e129b2d4",
+        "rev": "1615a7c471fe386a98f1397cb1d251ddd378098a",
         "type": "github"
       },
       "original": {
@@ -1908,11 +1908,11 @@
         "poetry2nix": "poetry2nix_5"
       },
       "locked": {
-        "lastModified": 1788448627,
-        "narHash": "sha256-+EkEWoKqsRSx08D3pnpYMOn90gOCfhDLRNUPf2dZLYM=",
+        "lastModified": 1788461331,
+        "narHash": "sha256-d8av6L0sktKz/wx8DhQyVaDUe3B16w2LZcGNfeqqDAo=",
         "owner": "Bootstrap-Academy",
         "repo": "skills-ms",
-        "rev": "0483369a93799e5ce6438606fe9325084269e11d",
+        "rev": "79321a3433ace955cebb9205505b3d554d7d1366",
         "type": "github"
       },
       "original": {
@@ -1928,11 +1928,11 @@
         "poetry2nix": "poetry2nix_6"
       },
       "locked": {
-        "lastModified": 1788448627,
-        "narHash": "sha256-+EkEWoKqsRSx08D3pnpYMOn90gOCfhDLRNUPf2dZLYM=",
+        "lastModified": 1788461331,
+        "narHash": "sha256-d8av6L0sktKz/wx8DhQyVaDUe3B16w2LZcGNfeqqDAo=",
         "owner": "Bootstrap-Academy",
         "repo": "skills-ms",
-        "rev": "0483369a93799e5ce6438606fe9325084269e11d",
+        "rev": "79321a3433ace955cebb9205505b3d554d7d1366",
         "type": "github"
       },
       "original": {

--- a/hosts/prod/backend/challenges.nix
+++ b/hosts/prod/backend/challenges.nix
@@ -4,6 +4,10 @@
   env,
   ...
 }:
+let
+  # the audiences this service talks to, plus its own for incoming tokens
+  internalJwtSecrets = config.academy.backend.internalJwtSecrets.values;
+in
 {
   imports = [ challenges-ms.nixosModules.default ];
 
@@ -112,6 +116,10 @@
     };
     templates."academy-backend/challenges-ms".content = ''
       CHALLENGES__SENTRY__DSN=${config.sops.placeholder."academy-backend/challenges-ms/sentry-dsn"}
+      INTERNAL_JWT_SECRETS__AUTH=${internalJwtSecrets.auth}
+      INTERNAL_JWT_SECRETS__SHOP=${internalJwtSecrets.shop}
+      INTERNAL_JWT_SECRETS__SKILLS=${internalJwtSecrets.skills}
+      INTERNAL_JWT_SECRETS__CHALLENGES=${internalJwtSecrets.challenges}
     '';
   };
 }

--- a/hosts/prod/backend/default.nix
+++ b/hosts/prod/backend/default.nix
@@ -4,6 +4,11 @@
   backend,
   ...
 }:
+let
+  # only the audiences the monolith serves (auth, shop) and calls (the three
+  # microservices it fans account deletions out to)
+  internalJwtSecrets = config.academy.backend.internalJwtSecrets.values;
+in
 {
   imports = [
     backend.nixosModules.default
@@ -169,6 +174,11 @@
             config.sops.placeholder."academy-backend/smtp-password"
           }@mail.your-server.de:587?tls=required"
           jwt.secret = "${config.sops.placeholder."academy-backend/jwt-secret"}"
+          internal.secrets.auth = "${internalJwtSecrets.auth}"
+          internal.secrets.shop = "${internalJwtSecrets.shop}"
+          internal.secrets.skills = "${internalJwtSecrets.skills}"
+          internal.secrets.challenges = "${internalJwtSecrets.challenges}"
+          internal.secrets.events = "${internalJwtSecrets.events}"
           recaptcha.secret = "${config.sops.placeholder."academy-backend/recaptcha-secret"}"
           paypal.client_secret = "${config.sops.placeholder."academy-backend/shop-ms/paypal-secret"}"
           sentry.dsn = "${config.sops.placeholder."academy-backend/sentry-dsn"}"

--- a/hosts/prod/backend/events.nix
+++ b/hosts/prod/backend/events.nix
@@ -6,6 +6,9 @@
 }:
 let
   ms = "events";
+
+  # the audiences this service talks to, plus its own for incoming tokens
+  internalJwtSecrets = config.academy.backend.internalJwtSecrets.values;
 in
 {
   imports = [ events-ms.nixosModules.default ];
@@ -44,11 +47,13 @@ in
   sops = {
     secrets = {
       "academy-backend/events-ms/sentry-dsn" = { };
-      "academy-backend/events-ms/calendar-secret" = { };
     };
     templates."academy-backend/events-ms".content = ''
       SENTRY_DSN=${config.sops.placeholder."academy-backend/events-ms/sentry-dsn"}
-      CALENDAR_SECRET=${config.sops.placeholder."academy-backend/events-ms/calendar-secret"}
+      INTERNAL_JWT_SECRET_AUTH=${internalJwtSecrets.auth}
+      INTERNAL_JWT_SECRET_SHOP=${internalJwtSecrets.shop}
+      INTERNAL_JWT_SECRET_SKILLS=${internalJwtSecrets.skills}
+      INTERNAL_JWT_SECRET_EVENTS=${internalJwtSecrets.events}
     '';
   };
 }

--- a/hosts/prod/backend/jobs.nix
+++ b/hosts/prod/backend/jobs.nix
@@ -6,6 +6,9 @@
 }:
 let
   ms = "jobs";
+
+  # the audiences this service talks to, plus its own for incoming tokens
+  internalJwtSecrets = config.academy.backend.internalJwtSecrets.values;
 in
 {
   imports = [ jobs-ms.nixosModules.default ];
@@ -36,6 +39,9 @@ in
     };
     templates."academy-backend/jobs-ms".content = ''
       SENTRY_DSN=${config.sops.placeholder."academy-backend/jobs-ms/sentry-dsn"}
+      INTERNAL_JWT_SECRET_AUTH=${internalJwtSecrets.auth}
+      INTERNAL_JWT_SECRET_SKILLS=${internalJwtSecrets.skills}
+      INTERNAL_JWT_SECRET_JOBS=${internalJwtSecrets.jobs}
     '';
   };
 }

--- a/hosts/prod/backend/skills.nix
+++ b/hosts/prod/backend/skills.nix
@@ -8,6 +8,9 @@
 
 let
   ms = "skills";
+
+  # the audiences this service talks to, plus its own for incoming tokens
+  internalJwtSecrets = config.academy.backend.internalJwtSecrets.values;
 in
 
 {
@@ -50,6 +53,9 @@ in
     };
     templates."academy-backend/skills-ms".content = ''
       SENTRY_DSN=${config.sops.placeholder."academy-backend/skills-ms/sentry-dsn"}
+      INTERNAL_JWT_SECRET_AUTH=${internalJwtSecrets.auth}
+      INTERNAL_JWT_SECRET_SHOP=${internalJwtSecrets.shop}
+      INTERNAL_JWT_SECRET_SKILLS=${internalJwtSecrets.skills}
     '';
   };
 }

--- a/hosts/test/backend/challenges.nix
+++ b/hosts/test/backend/challenges.nix
@@ -5,6 +5,11 @@
   ...
 }:
 
+let
+  # the audiences this service talks to, plus its own for incoming tokens
+  internalJwtSecrets = config.academy.backend.internalJwtSecrets.values;
+in
+
 {
   imports = [ challenges-ms-develop.nixosModules.default ];
 
@@ -113,6 +118,10 @@
     };
     templates."academy-backend/challenges-ms".content = ''
       CHALLENGES__SENTRY__DSN=${config.sops.placeholder."academy-backend/challenges-ms/sentry-dsn"}
+      INTERNAL_JWT_SECRETS__AUTH=${internalJwtSecrets.auth}
+      INTERNAL_JWT_SECRETS__SHOP=${internalJwtSecrets.shop}
+      INTERNAL_JWT_SECRETS__SKILLS=${internalJwtSecrets.skills}
+      INTERNAL_JWT_SECRETS__CHALLENGES=${internalJwtSecrets.challenges}
     '';
   };
 }

--- a/hosts/test/backend/default.nix
+++ b/hosts/test/backend/default.nix
@@ -4,6 +4,11 @@
   backend-develop,
   ...
 }:
+let
+  # only the audiences the monolith serves (auth, shop) and calls (the three
+  # microservices it fans account deletions out to)
+  internalJwtSecrets = config.academy.backend.internalJwtSecrets.values;
+in
 {
   imports = [
     backend-develop.nixosModules.default
@@ -170,6 +175,11 @@
             config.sops.placeholder."academy-backend/smtp-password"
           }@mail.your-server.de:587?tls=required"
           jwt.secret = "${config.sops.placeholder."academy-backend/jwt-secret"}"
+          internal.secrets.auth = "${internalJwtSecrets.auth}"
+          internal.secrets.shop = "${internalJwtSecrets.shop}"
+          internal.secrets.skills = "${internalJwtSecrets.skills}"
+          internal.secrets.challenges = "${internalJwtSecrets.challenges}"
+          internal.secrets.events = "${internalJwtSecrets.events}"
           recaptcha.secret = "${config.sops.placeholder."academy-backend/recaptcha-secret"}"
           paypal.client_secret = "${config.sops.placeholder."academy-backend/shop-ms/paypal-secret"}"
           sentry.dsn = "${config.sops.placeholder."academy-backend/sentry-dsn"}"

--- a/hosts/test/backend/events.nix
+++ b/hosts/test/backend/events.nix
@@ -6,6 +6,9 @@
 }:
 let
   ms = "events";
+
+  # the audiences this service talks to, plus its own for incoming tokens
+  internalJwtSecrets = config.academy.backend.internalJwtSecrets.values;
 in
 {
   imports = [ events-ms-develop.nixosModules.default ];
@@ -44,11 +47,13 @@ in
   sops = {
     secrets = {
       "academy-backend/events-ms/sentry-dsn" = { };
-      "academy-backend/events-ms/calendar-secret" = { };
     };
     templates."academy-backend/events-ms".content = ''
       SENTRY_DSN=${config.sops.placeholder."academy-backend/events-ms/sentry-dsn"}
-      CALENDAR_SECRET=${config.sops.placeholder."academy-backend/events-ms/calendar-secret"}
+      INTERNAL_JWT_SECRET_AUTH=${internalJwtSecrets.auth}
+      INTERNAL_JWT_SECRET_SHOP=${internalJwtSecrets.shop}
+      INTERNAL_JWT_SECRET_SKILLS=${internalJwtSecrets.skills}
+      INTERNAL_JWT_SECRET_EVENTS=${internalJwtSecrets.events}
     '';
   };
 }

--- a/hosts/test/backend/jobs.nix
+++ b/hosts/test/backend/jobs.nix
@@ -6,6 +6,9 @@
 }:
 let
   ms = "jobs";
+
+  # the audiences this service talks to, plus its own for incoming tokens
+  internalJwtSecrets = config.academy.backend.internalJwtSecrets.values;
 in
 {
   imports = [ jobs-ms-develop.nixosModules.default ];
@@ -36,6 +39,9 @@ in
     };
     templates."academy-backend/jobs-ms".content = ''
       SENTRY_DSN=${config.sops.placeholder."academy-backend/jobs-ms/sentry-dsn"}
+      INTERNAL_JWT_SECRET_AUTH=${internalJwtSecrets.auth}
+      INTERNAL_JWT_SECRET_SKILLS=${internalJwtSecrets.skills}
+      INTERNAL_JWT_SECRET_JOBS=${internalJwtSecrets.jobs}
     '';
   };
 }

--- a/hosts/test/backend/skills.nix
+++ b/hosts/test/backend/skills.nix
@@ -8,6 +8,9 @@
 
 let
   ms = "skills";
+
+  # the audiences this service talks to, plus its own for incoming tokens
+  internalJwtSecrets = config.academy.backend.internalJwtSecrets.values;
 in
 
 {
@@ -50,6 +53,9 @@ in
     };
     templates."academy-backend/skills-ms".content = ''
       SENTRY_DSN=${config.sops.placeholder."academy-backend/skills-ms/sentry-dsn"}
+      INTERNAL_JWT_SECRET_AUTH=${internalJwtSecrets.auth}
+      INTERNAL_JWT_SECRET_SHOP=${internalJwtSecrets.shop}
+      INTERNAL_JWT_SECRET_SKILLS=${internalJwtSecrets.skills}
     '';
   };
 }

--- a/modules/backend/default.nix
+++ b/modules/backend/default.nix
@@ -1,5 +1,6 @@
 { lib, ... }: {
   imports = [
+    ./internal-jwt-secrets.nix
     ./nginx.nix
     ./postgresql.nix
     ./redis.nix

--- a/modules/backend/internal-jwt-secrets.nix
+++ b/modules/backend/internal-jwt-secrets.nix
@@ -1,0 +1,74 @@
+{ config, lib, ... }:
+
+let
+  cfg = config.academy.backend.internalJwtSecrets;
+
+  secretName = audience: "academy-backend/internal-jwt-secret/${audience}";
+in
+
+{
+  options.academy.backend.internalJwtSecrets = {
+    enable = lib.mkEnableOption ''
+      per audience secrets for the internal service tokens.
+
+      The monolith and the microservices then sign a service token with the
+      secret of the audience it is addressed to, and verify an incoming one
+      with the secret of their own audience, instead of using the shared
+      `academy-backend/jwt-secret` for everything. A key taken from one service
+      can therefore no longer be used to talk to another one.
+
+      Every service only receives the secrets of the audiences it actually
+      talks to plus its own.
+
+      Requires one secret per audience in the host's `secrets.yml`, activation
+      fails without them:
+
+      ```yaml
+      academy-backend:
+          internal-jwt-secret:
+              auth: <64 random bytes, base64>
+              shop: <64 random bytes, base64>
+              skills: <64 random bytes, base64>
+              challenges: <64 random bytes, base64>
+              events: <64 random bytes, base64>
+              jobs: <64 random bytes, base64>
+      ```
+
+      While this is off every audience is handed an empty value, which the
+      services read as "fall back to the shared jwt secret". That is the
+      behaviour of the deployment as it stands today
+    '';
+
+    audiences = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [
+        "auth"
+        "shop"
+        "skills"
+        "challenges"
+        "events"
+        "jobs"
+      ];
+      readOnly = true;
+      description = "The audiences an internal service token can be issued for.";
+    };
+
+    values = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      readOnly = true;
+      default = lib.genAttrs cfg.audiences (
+        audience: lib.optionalString cfg.enable config.sops.placeholder.${secretName audience}
+      );
+      defaultText = lib.literalMD ''
+        the sops placeholder of each audience's secret, or an empty string while
+        this is disabled
+      '';
+      description = ''
+        The value to interpolate into a secret template, per audience. Only the
+        audiences a service talks to belong into its template.
+      '';
+    };
+  };
+
+  config.sops.secrets = lib.mkIf cfg.enable (lib.genAttrs (map secretName cfg.audiences) (_: { }));
+}


### PR DESCRIPTION
Two commits that belong together: the per-audience secret module for the
internal service tokens, and the input bump that pins the service revisions
which make it — and the removal of `CALENDAR_SECRET` — correct.

## 1. `academy.backend.internalJwtSecrets` (disabled)

`modules/backend/internal-jwt-secrets.nix` adds one secret per audience
(`auth`, `shop`, `skills`, `challenges`, `events`, `jobs`) and hands each host
template only the audiences that service talks to plus its own:

| service | template keys |
|---|---|
| backend (monolith) | `internal.secrets.{auth,shop,skills,challenges,events}` |
| skills-ms | `INTERNAL_JWT_SECRET_{AUTH,SHOP,SKILLS}` |
| events-ms | `INTERNAL_JWT_SECRET_{AUTH,SHOP,SKILLS,EVENTS}` |
| jobs-ms | `INTERNAL_JWT_SECRET_{AUTH,SKILLS,JOBS}` |
| challenges-ms | `INTERNAL_JWT_SECRETS__{AUTH,SHOP,SKILLS,CHALLENGES}` (double underscore — its config crate nests on `__`) |

**The option ships `enable = false`.** While it is off, every audience is
handed an empty string and no new sops secret is declared; all five services
read an empty value as "use the shared `jwt.secret`", on signing and on
verification alike, so the rendered configuration behaves exactly like today's.
Turning it on later needs one secret per audience under
`academy-backend/internal-jwt-secret/<audience>` in the host's `secrets.yml`;
the option documentation lists the names.

Verified by evaluation on this branch:

- `nix build --dry-run .#checks` evaluates all three hosts (`prod`, `test`,
  `sandkasten`).
- with the option off, `sops.templates."academy-backend/events-ms".content`
  renders `INTERNAL_JWT_SECRET_AUTH=` … (empty) and
  `academy-backend/config` renders `internal.secrets.auth = ""` …; no
  `academy-backend/internal-jwt-secret/*` secret is declared.
- with the option flipped on locally (not committed), the same templates render
  the six sops placeholders and the six secrets are declared.
- `nix fmt -- --ci` is clean.

## 2. Input bump

Every Bootstrap-Academy input moves to the current head of the branch it
tracks, so the prod hosts pin each service's `latest` and the test host its
`develop`:

| input | from | to | branch |
|---|---|---|---|
| `backend` | `f0e5ed6` | `63fcc42` | `develop` |
| `backend-develop` | `f0e5ed6` | `63fcc42` | `develop` |
| `skills-ms` | `0483369` | `79321a3` | `latest` |
| `skills-ms-develop` | `0483369` | `79321a3` | `develop` |
| `challenges-ms` | `52eefe3` | `6c7a239` | `latest` |
| `challenges-ms-develop` | `52eefe3` | `1bd346b` | `develop` |
| `events-ms` | `fece9e1` | `cdbe3c4` | `latest` |
| `events-ms-develop` | `a8a1a8a` | `3994f4b` | `develop` |
| `jobs-ms` | `eb89be9` | `f93cc6b` | `latest` |
| `jobs-ms-develop` | `60cf980` | `1615a7c` | `develop` |

`sandkasten` and the nixpkgs inputs are deliberately untouched; the lock diff
contains these ten nodes and nothing else.

These revisions carry the per-audience secret support in all five services, the
account-deletion fan-out fixes, the data export endpoints, the leaderboard
visibility flag, the document retention work and the admin audit log.

## Why the two commits cannot be split

`hosts/{prod,test}/backend/events.nix` drop the
`academy-backend/events-ms/calendar-secret` sops secret and the
`CALENDAR_SECRET=` template line. That is only correct for an events-ms
revision that no longer reads the variable — `cdbe3c4` (`latest`) and `3994f4b`
(`develop`) are the first such revisions, and both are pinned by the same
commit pair.

**The calendar subscription urls change with this release: the ics feed now
uses a random per-user token instead of an hmac of `CALENDAR_SECRET`, so every
existing subscription url stops working and each user has to copy the new one
from the calendar page once.** That is the point of the change — the old url
could not be revoked for a single user. The calendar page already shows the new
link and a renew button.

Supersedes the partial lock bump on `chore/bump-user-deletion-fixes`, which is
deleted with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
