### PR TITLE
feat(backend): name the OAuth2 redirect uris of each instance

### DIFF
--- a/hosts/prod/backend/default.nix
+++ b/hosts/prod/backend/default.nix
@@ -70,6 +70,11 @@ in
         client_id = "ATyoxdWxm36bTHFypQ2lVOwDQc4lKr0CkQs6NO03HfzFjnnM-6RIre6_ycFFQDP1Iez6zVxEe6o2FHu7";
       };
 
+      # `POST /auth/oauth/authorize` accepts only the redirect uris listed here.
+      # This is also the backend's default; it is written out so that the
+      # instance says which callback it allows.
+      oauth2.redirect_uris = [ "https://bootstrap.academy/oauth/callback" ];
+
       oauth2.providers = {
         github.client_id = "4f869d4f526dbb56864b";
         discord.client_id = "1034866261181607997";

--- a/hosts/test/backend/default.nix
+++ b/hosts/test/backend/default.nix
@@ -74,6 +74,11 @@ in
         client_id = "AY8tdE7PPpUOVbURYdFvrqsisOiJpggHWnNYphRQjbDPCoPcD3z7XUU067hZ6kf4cH82GwQrAkJnhcqn";
       };
 
+      # `POST /auth/oauth/authorize` accepts only the redirect uris listed here.
+      # The default in the backend is the production callback, so this instance
+      # has to name its own.
+      oauth2.redirect_uris = [ "https://test.bootstrap.academy/oauth/callback" ];
+
       oauth2.providers = {
         github.client_id = "87e19e5e68c83d9595a3";
         discord.client_id = "1019985764735537202";


### PR DESCRIPTION
The backend now accepts only the redirect uris listed in `oauth2.redirect_uris` when an OAuth2 authorization flow is started (`POST /auth/oauth/authorize`), and its own default is the production callback. The test instance is reached under another domain and therefore has to name its own, or OAuth2 login stops working there once the backend input is bumped. Production writes its own out as well, so that each instance says which callback it allows rather than relying on the default.

Inert until the backend input is bumped: an unknown key in the backend's TOML configuration is ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ULMZAG22fLd8jzcMnYMoPx