### PR TITLE
chore: bump the backend, challenges-ms and events-ms inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1788709302,
-        "narHash": "sha256-wVQoN19JAZdNnjfBFVYsUM+VLOdo5uiVdiEH+cZ34KI=",
+        "lastModified": 1788746340,
+        "narHash": "sha256-oveRmsmZ5K1J0Z5gqdcpAItW0JFRKJclsd4QlYAF7v4=",
         "owner": "Bootstrap-Academy",
         "repo": "backend",
-        "rev": "63fcc42feaa52b63e7964c3b7dd752714abe2048",
+        "rev": "59f45cf862b533829fbfa8ac4e2c2a7ecbf524a9",
         "type": "github"
       },
       "original": {
@@ -28,11 +28,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1788709302,
-        "narHash": "sha256-wVQoN19JAZdNnjfBFVYsUM+VLOdo5uiVdiEH+cZ34KI=",
+        "lastModified": 1788746340,
+        "narHash": "sha256-oveRmsmZ5K1J0Z5gqdcpAItW0JFRKJclsd4QlYAF7v4=",
         "owner": "Bootstrap-Academy",
         "repo": "backend",
-        "rev": "63fcc42feaa52b63e7964c3b7dd752714abe2048",
+        "rev": "59f45cf862b533829fbfa8ac4e2c2a7ecbf524a9",
         "type": "github"
       },
       "original": {
@@ -122,11 +122,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1788710581,
-        "narHash": "sha256-4e89Rkc2OxMXxaxZaTxy812W3tBmU5VaNcPPrPLn+Oo=",
+        "lastModified": 1788748261,
+        "narHash": "sha256-aEdErO/MO5ldGC55ZshzAS4xHAEe/pVwgRanANAejGc=",
         "owner": "Bootstrap-Academy",
         "repo": "challenges-ms",
-        "rev": "6c7a2393e69d8aceaa3a1ff66b46d867cbaf0f75",
+        "rev": "baba9c0c2d88b6def683e37ab4b616d28a528229",
         "type": "github"
       },
       "original": {
@@ -142,11 +142,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1788710463,
-        "narHash": "sha256-4e89Rkc2OxMXxaxZaTxy812W3tBmU5VaNcPPrPLn+Oo=",
+        "lastModified": 1788748144,
+        "narHash": "sha256-aEdErO/MO5ldGC55ZshzAS4xHAEe/pVwgRanANAejGc=",
         "owner": "Bootstrap-Academy",
         "repo": "challenges-ms",
-        "rev": "1bd346b750fecc5b3b9545e6334d41119f143c10",
+        "rev": "7e1fb52db995f36f658b38541a987cd149bb33fe",
         "type": "github"
       },
       "original": {
@@ -307,11 +307,11 @@
         "poetry2nix": "poetry2nix"
       },
       "locked": {
-        "lastModified": 1788711050,
-        "narHash": "sha256-IxsdhmV4KM5CfyvUoBtdXWyTRcbrtgwzs5ukQB3Nbr0=",
+        "lastModified": 1788748187,
+        "narHash": "sha256-THa4usd+y7Y8U5+hdKh3OAZZx2YFdDfAFKh0zz6PXk8=",
         "owner": "Bootstrap-Academy",
         "repo": "events-ms",
-        "rev": "cdbe3c4e1c54225b3a1d69b2e8337ba75f04a906",
+        "rev": "a1fc97b2a5b3f9421bd48073c5884697350339a4",
         "type": "github"
       },
       "original": {
@@ -327,11 +327,11 @@
         "poetry2nix": "poetry2nix_2"
       },
       "locked": {
-        "lastModified": 1788461548,
-        "narHash": "sha256-lYgkRaO596Mt/Ni1Gp14tGqienS7soQWOYEybCZF8Mc=",
+        "lastModified": 1788747988,
+        "narHash": "sha256-THa4usd+y7Y8U5+hdKh3OAZZx2YFdDfAFKh0zz6PXk8=",
         "owner": "Bootstrap-Academy",
         "repo": "events-ms",
-        "rev": "3994f4b1765a22085f6c3809e05b9d4265e95c29",
+        "rev": "39c45330bafde3b2ead31452b4941ac20b123a20",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps the Bootstrap-Academy inputs that moved since the previous bump on `staging`. Four of the ten are already at their branch heads and stay where they are; `sandkasten`, nixpkgs and every other input are untouched.

### Rev moves

| Input | Branch | From | To |
| --- | --- | --- | --- |
| `backend` | `develop` | `63fcc42` | `59f45cf` |
| `backend-develop` | `develop` | `63fcc42` | `59f45cf` |
| `challenges-ms` | `latest` | `6c7a239` | `baba9c0` |
| `challenges-ms-develop` | `develop` | `1bd346b` | `7e1fb52` |
| `events-ms` | `latest` | `cdbe3c4` | `a1fc97b` |
| `events-ms-develop` | `develop` | `3994f4b` | `39c4533` |

Already current, not moved: `skills-ms` and `skills-ms-develop` at `79321a3`, `jobs-ms` at `f93cc6b`, `jobs-ms-develop` at `1615a7c`.

### What the backend rev carries (#730, #735–#748)

- An OAuth2 authorization is bound to a server-side state and uses PKCE with all three providers, can only be completed for what it was started for, and only the redirect uris the deployment lists are accepted (#730, #743).
- Invoices, confirmations and the purchase e-mail print every number in German notation (#735).
- The accepted terms version is taken from the server instead of from the request body, named by the new `user.terms_version` setting (#735).
- The two declaration endpoints get a budget a shared address survives — 60 per hour and client address, 5 per hour and e-mail address — configurable under `[contract]` (#735).
- Every issued document is recorded, and a second download returns the stored file instead of generating a new one (#736).
- Only the version of the withdrawal instruction that is in force is accepted (#737).
- The line items of a document add up to its net total and its total (#738).
- The configuration reference and the request-body descriptions match what the code does (#739).
- The two tables that are read by user id are indexed (#740).
- Documents are dated in `Europe/Berlin`, an invoice is dated with the payment rather than with the order, a final statement is issued only when there is something to refund and records when it has been paid out, an archived document is written atomically, two listings return what was asked for, and a vat rate that cannot produce a valid invoice is rejected by the configuration check (#741).
- Account deletion logs the session out only once the deletion is committed, and the final statement is rendered outside the transaction (#742).
- Administrative authority ends when the second factor is removed, the break-glass token is signed with the secret of its audience, and personal data no longer reaches the tracing spans (#743, #744).
- The terms attached to the purchase e-mail are regenerated from the current pages (#744, #745).
- Cancellation and withdrawal declarations are deleted by `academy task prune-database` once the limitation period is over, after the new `contract.retention_years` (#746).
- The withdrawal declarations of a coin order are kept with the invoice record (#747).
- The name-change and export waiting periods that administrators are exempt from go through the same check as every other privilege (#748).

The new keys ship with defaults in the backend's `config.toml`; `oauth2.redirect_uris` is already named per instance since #62.

### What the challenges-ms rev carries (#326/#327, #328/#329, #330/#331)

- A user-created subtask is hidden after ten negative ratings — the tally compared the wrong column, so the rule never fired.
- The four schemas of the internal user export get names of their own; two of them collided with older schemas, which made the service abort while building its API description at startup.
- `GET /challenges/leaderboard/{user_id}` reads the user id from the path instead of from the query string.

### What the events-ms rev carries (#218/#219, #220/#221)

- Cancelling a calendar event refunds the participants instead of charging them a second time.
- What a booking was charged is written down when it is made, and every payment back is computed from that amount rather than from the current price of the event, so a booking that cost nothing pays nothing back.
- A booking whose confirmation mail cannot be sent is no longer answered with an error after the coins have been taken.

### Verified

- `nix flake update` was run for exactly these six inputs; the diff touches 18 lines of `flake.lock` and no other node.
- `nix build --dry-run .#checks` evaluates on this branch and lists `nixos-system-prod`, `nixos-system-test` and `nixos-system-sandkasten`, with `academy-2026.09.07+59f45cf`.
- `nix fmt -- --ci`: 60 files traversed, 0 changed.
- `latest` and `develop` carry identical trees in challenges-ms, events-ms and skills-ms. jobs-ms differs only in `.github/workflows/build.yml` and one transitive `poetry.lock` entry, both predating this line of work and neither part of the service, so no release cherry-pick was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
