### PR TITLE
chore: bump the backend input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1788746340,
-        "narHash": "sha256-oveRmsmZ5K1J0Z5gqdcpAItW0JFRKJclsd4QlYAF7v4=",
+        "lastModified": 1788757367,
+        "narHash": "sha256-fPus1eZDVrqsIq97qOWeixeVqygWo0O3hVGphxYTjCE=",
         "owner": "Bootstrap-Academy",
         "repo": "backend",
-        "rev": "59f45cf862b533829fbfa8ac4e2c2a7ecbf524a9",
+        "rev": "478551164cffedf976ae9715832e6cebf324f69b",
         "type": "github"
       },
       "original": {
@@ -28,11 +28,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1788746340,
-        "narHash": "sha256-oveRmsmZ5K1J0Z5gqdcpAItW0JFRKJclsd4QlYAF7v4=",
+        "lastModified": 1788757367,
+        "narHash": "sha256-fPus1eZDVrqsIq97qOWeixeVqygWo0O3hVGphxYTjCE=",
         "owner": "Bootstrap-Academy",
         "repo": "backend",
-        "rev": "59f45cf862b533829fbfa8ac4e2c2a7ecbf524a9",
+        "rev": "478551164cffedf976ae9715832e6cebf324f69b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Follow-up to #63. Only the backend moved since that bump; every microservice input is still at the head of the branch it follows and is untouched, as are `sandkasten`, nixpkgs and every other input. The diff is 6 lines of `flake.lock`.

### Rev moves

| Input | Branch | From | To |
| --- | --- | --- | --- |
| `backend` | `develop` | `59f45cf` | `4785511` |
| `backend-develop` | `develop` | `59f45cf` | `4785511` |

Unchanged, already at their heads: `skills-ms` / `skills-ms-develop` `79321a3`, `challenges-ms` `baba9c0`, `challenges-ms-develop` `7e1fb52`, `events-ms` `a1fc97b`, `events-ms-develop` `39c4533`, `jobs-ms` `f93cc6b`, `jobs-ms-develop` `1615a7c`.

### What the new revision carries (#749, #750)

- The login and the failed-attempt counter no longer put the identifier a caller logged in with into the tracing spans (#749).
- Two administrative reads that were not recorded before — the listing of the declarations and the listing of a user's sessions — go through the audit middleware (#749), asserted by `nix/tests/admin-audit.py`.
- `agb-2026-09.pdf`, the copy attached to the purchase e-mail, is re-rendered from the current terms page; its hash in `nix/tests/paypal.py` moves with it (#750).

### Verified

- `nix flake update` was run for exactly these two inputs; no other node in `flake.lock` changed.
- `nix build --dry-run .#checks` evaluates on this branch and lists `nixos-system-prod`, `nixos-system-test` and `nixos-system-sandkasten`, with `academy-2026.09.07+4785511`.
- `nix fmt -- --ci`: 60 files traversed, 0 changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
