### PR TITLE
chore: bump the backend input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1788757367,
-        "narHash": "sha256-fPus1eZDVrqsIq97qOWeixeVqygWo0O3hVGphxYTjCE=",
+        "lastModified": 1788775474,
+        "narHash": "sha256-T2WTQ2KagkVnFURgnArYKg2Y9pp2Sju7AQX0NQf5wfc=",
         "owner": "Bootstrap-Academy",
         "repo": "backend",
-        "rev": "478551164cffedf976ae9715832e6cebf324f69b",
+        "rev": "fd412f9325944ab7f22709b042531628f89e994d",
         "type": "github"
       },
       "original": {
@@ -28,11 +28,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1788757367,
-        "narHash": "sha256-fPus1eZDVrqsIq97qOWeixeVqygWo0O3hVGphxYTjCE=",
+        "lastModified": 1788775474,
+        "narHash": "sha256-T2WTQ2KagkVnFURgnArYKg2Y9pp2Sju7AQX0NQf5wfc=",
         "owner": "Bootstrap-Academy",
         "repo": "backend",
-        "rev": "478551164cffedf976ae9715832e6cebf324f69b",
+        "rev": "fd412f9325944ab7f22709b042531628f89e994d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Follow-up to #64. Only the backend moved since that bump; every microservice input is still at the head of the branch it follows and is untouched, as are `sandkasten`, nixpkgs and every other input. The diff is 6 lines of `flake.lock`.

### Rev moves

| Input | Branch | From | To |
| --- | --- | --- | --- |
| `backend` | `develop` | `4785511` | `fd412f9` |
| `backend-develop` | `develop` | `4785511` | `fd412f9` |

Unchanged, already at their heads: `skills-ms` / `skills-ms-develop` `79321a3`, `challenges-ms` `baba9c0`, `challenges-ms-develop` `7e1fb52`, `events-ms` `a1fc97b`, `events-ms-develop` `39c4533`, `jobs-ms` `f93cc6b`, `jobs-ms-develop` `1615a7c`.

### What the new revision carries (#751–#754)

- Repeated failed logins are refused for a growing period instead of only being asked for a captcha: a login locks after five failures in a quarter of an hour and each further failure doubles the lock up to fifteen minutes, with a separate failure budget per client address. A successful login clears the counter (#751).
- A premium term of "one month" or "one year" is a calendar month or a calendar year rather than a twelfth of an average year (#752).
- Cancellation and withdrawal declarations carry a free-text designation of what is being declared and a processing state, so a declaration can be tracked from receipt to completion (#753).
- The `Retry-After` header is exposed through CORS, so the browser can read how long it has to wait when it is throttled (#754).

New settings — `session.login_fails_before_lock`, `login_fail_window`, `login_lock_initial`, `login_lock_max`, `login_fails_per_ip`, `login_ip_window` — ship with defaults in the backend's `config.toml`, so no module change is needed here. The revision also brings one database migration.

### Verified

- `nix flake update` was run for exactly these two inputs; no other node in `flake.lock` changed.
- `nix build --dry-run .#checks` evaluates on this branch and lists `nixos-system-prod`, `nixos-system-test` and `nixos-system-sandkasten`, with `academy-2026.09.07+fd412f9`.
- `nix fmt -- --ci`: 60 files traversed, 0 changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
