### PR TITLE
Keep skill-tree course definitions in the deployment closure

### DIFF
--- a/hosts/prod/backend/skills.nix
+++ b/hosts/prod/backend/skills.nix
@@ -11,10 +11,28 @@ let
 
   # the audiences this service talks to, plus its own for incoming tokens
   internalJwtSecrets = config.academy.backend.internalJwtSecrets.values;
+  coursesPath = config.academy.backend.skills.settings.COURSES;
+  coursesContext = builtins.getContext coursesPath;
+  courseFiles = if builtins.pathExists coursesPath then builtins.readDir coursesPath else { };
 in
 
 {
   imports = [ skills-ms.nixosModules.default ];
+
+  assertions = [
+    {
+      assertion = lib.any (path: path == coursesPath && (coursesContext.${path}.path or false)) (
+        builtins.attrNames coursesContext
+      );
+      message = "Skills COURSES must retain its store-path reference in the deployment closure.";
+    }
+    {
+      assertion = lib.any (name: lib.hasSuffix ".yml" name && courseFiles.${name} == "regular") (
+        builtins.attrNames courseFiles
+      );
+      message = "Skills COURSES must contain course YAML definitions.";
+    }
+  ];
 
   academy.backend.microservices.skills = {
     port = 8001;
@@ -38,7 +56,7 @@ in
       PUBLIC_BASE_URL = "https://${config.academy.backend.domain}/${ms}";
       DATABASE_URL = "postgresql+asyncpg://academy-${ms}@/academy-${ms}?host=/run/postgresql";
 
-      COURSES = toString skills-ms.packages.${system}.courses;
+      COURSES = "${skills-ms.packages.${system}.courses}";
 
       LECTURE_XP = "10";
       MP4_LECTURES = "/mnt/lectures";

--- a/hosts/test/backend/skills.nix
+++ b/hosts/test/backend/skills.nix
@@ -11,10 +11,28 @@ let
 
   # the audiences this service talks to, plus its own for incoming tokens
   internalJwtSecrets = config.academy.backend.internalJwtSecrets.values;
+  coursesPath = config.academy.backend.skills.settings.COURSES;
+  coursesContext = builtins.getContext coursesPath;
+  courseFiles = if builtins.pathExists coursesPath then builtins.readDir coursesPath else { };
 in
 
 {
   imports = [ skills-ms-develop.nixosModules.default ];
+
+  assertions = [
+    {
+      assertion = lib.any (path: path == coursesPath && (coursesContext.${path}.path or false)) (
+        builtins.attrNames coursesContext
+      );
+      message = "Skills COURSES must retain its store-path reference in the deployment closure.";
+    }
+    {
+      assertion = lib.any (name: lib.hasSuffix ".yml" name && courseFiles.${name} == "regular") (
+        builtins.attrNames courseFiles
+      );
+      message = "Skills COURSES must contain course YAML definitions.";
+    }
+  ];
 
   academy.backend.microservices.skills = {
     port = 8001;
@@ -38,7 +56,7 @@ in
       PUBLIC_BASE_URL = "https://${config.academy.backend.domain}/${ms}";
       DATABASE_URL = "postgresql+asyncpg://academy-${ms}@/academy-${ms}?host=/run/postgresql";
 
-      COURSES = toString skills-ms-develop.packages.${system}.courses;
+      COURSES = "${skills-ms-develop.packages.${system}.courses}";
 
       LECTURE_XP = "10";
       MP4_LECTURES = "/mnt/lectures";


### PR DESCRIPTION
The Skills service loaded an empty course catalog because `toString` removed the Nix store context from `COURSES`. The resulting source path could be absent on the deployed host even while the service and skill-tree database remained healthy, causing course summaries such as Python, Java and Kotlin to return 404.

Use path interpolation for both production and test so the course definitions become an explicit deployment dependency. Add assertions that the configured path retains its exact store reference and contains course YAML files. Application pins, course contents and database behavior remain unchanged.

Validation:

- Full production and test NixOS evaluations pass; both include all 85 course definitions and reference the course path in their derivation dependency closures.
- A regression probe that removes the store context fails the new assertion.
- Repository formatting and whitespace checks pass.
- Full production and test system builds pass. After activation on both hosts, the catalog contains 85 courses and Python/Java/Kotlin summaries return 200; all services remain healthy.
- Authenticated browser smoke on test confirms visible Python, Java and Kotlin course cards without JavaScript errors.
