### PR TITLE
Enable public feedback with guarded moderation mail

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,17 +7,17 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1789136737,
-        "narHash": "sha256-YwWaN7PMYi0oSaGWQQFIoXKUcr4Gmn/uRjtKcbbSt5U=",
+        "lastModified": 1789201767,
+        "narHash": "sha256-xZVjaZ+arskvj4sE3elPCTjqY8C1USic/t4nJcuGOZ4=",
         "owner": "Bootstrap-Academy",
         "repo": "backend",
-        "rev": "ba62852fc4d76f8a38c6ce99f46abbaba3714062",
+        "rev": "56e8b849d4b45e27d4495e89f524ed22d75cf49a",
         "type": "github"
       },
       "original": {
         "owner": "Bootstrap-Academy",
         "repo": "backend",
-        "rev": "ba62852fc4d76f8a38c6ce99f46abbaba3714062",
+        "rev": "56e8b849d4b45e27d4495e89f524ed22d75cf49a",
         "type": "github"
       }
     },
@@ -28,17 +28,17 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1789136737,
-        "narHash": "sha256-YwWaN7PMYi0oSaGWQQFIoXKUcr4Gmn/uRjtKcbbSt5U=",
+        "lastModified": 1789201767,
+        "narHash": "sha256-xZVjaZ+arskvj4sE3elPCTjqY8C1USic/t4nJcuGOZ4=",
         "owner": "Bootstrap-Academy",
         "repo": "backend",
-        "rev": "ba62852fc4d76f8a38c6ce99f46abbaba3714062",
+        "rev": "56e8b849d4b45e27d4495e89f524ed22d75cf49a",
         "type": "github"
       },
       "original": {
         "owner": "Bootstrap-Academy",
         "repo": "backend",
-        "rev": "ba62852fc4d76f8a38c6ce99f46abbaba3714062",
+        "rev": "56e8b849d4b45e27d4495e89f524ed22d75cf49a",
         "type": "github"
       }
     },
@@ -122,17 +122,17 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1789128298,
-        "narHash": "sha256-bY38mHz6Wl5NM18+QgOp6arnrruQWSSWdpVmrUy4KAw=",
+        "lastModified": 1789201805,
+        "narHash": "sha256-f0we3VjTPzSFr5wdURM1rAHeaxTzqpU3YLqrlGqYTWA=",
         "owner": "Bootstrap-Academy",
         "repo": "challenges-ms",
-        "rev": "6c4a7453b970212c31639048d59baccd87220e29",
+        "rev": "fcc9f52e568d322712a77552d404fab32fb1894c",
         "type": "github"
       },
       "original": {
         "owner": "Bootstrap-Academy",
         "repo": "challenges-ms",
-        "rev": "6c4a7453b970212c31639048d59baccd87220e29",
+        "rev": "fcc9f52e568d322712a77552d404fab32fb1894c",
         "type": "github"
       }
     },
@@ -142,17 +142,17 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1789128298,
-        "narHash": "sha256-bY38mHz6Wl5NM18+QgOp6arnrruQWSSWdpVmrUy4KAw=",
+        "lastModified": 1789201805,
+        "narHash": "sha256-f0we3VjTPzSFr5wdURM1rAHeaxTzqpU3YLqrlGqYTWA=",
         "owner": "Bootstrap-Academy",
         "repo": "challenges-ms",
-        "rev": "6c4a7453b970212c31639048d59baccd87220e29",
+        "rev": "fcc9f52e568d322712a77552d404fab32fb1894c",
         "type": "github"
       },
       "original": {
         "owner": "Bootstrap-Academy",
         "repo": "challenges-ms",
-        "rev": "6c4a7453b970212c31639048d59baccd87220e29",
+        "rev": "fcc9f52e568d322712a77552d404fab32fb1894c",
         "type": "github"
       }
     },
@@ -307,17 +307,17 @@
         "poetry2nix": "poetry2nix"
       },
       "locked": {
-        "lastModified": 1789129712,
-        "narHash": "sha256-zCK6UiIg2OyrRcYjHl3ek+/h5gU61UoE19mC7niOW+Y=",
+        "lastModified": 1789201881,
+        "narHash": "sha256-mS4gLRILtVc2j7ITAH/OfWPUdxfhVPE+dieIwajRw7Q=",
         "owner": "Bootstrap-Academy",
         "repo": "events-ms",
-        "rev": "337d3002183c7420a1ebd2bb38474350c36eb7cb",
+        "rev": "ff767ea8f76a253995b53fcfeb1217fe79f19da5",
         "type": "github"
       },
       "original": {
         "owner": "Bootstrap-Academy",
         "repo": "events-ms",
-        "rev": "337d3002183c7420a1ebd2bb38474350c36eb7cb",
+        "rev": "ff767ea8f76a253995b53fcfeb1217fe79f19da5",
         "type": "github"
       }
     },
@@ -327,17 +327,17 @@
         "poetry2nix": "poetry2nix_2"
       },
       "locked": {
-        "lastModified": 1789129712,
-        "narHash": "sha256-zCK6UiIg2OyrRcYjHl3ek+/h5gU61UoE19mC7niOW+Y=",
+        "lastModified": 1789201881,
+        "narHash": "sha256-mS4gLRILtVc2j7ITAH/OfWPUdxfhVPE+dieIwajRw7Q=",
         "owner": "Bootstrap-Academy",
         "repo": "events-ms",
-        "rev": "337d3002183c7420a1ebd2bb38474350c36eb7cb",
+        "rev": "ff767ea8f76a253995b53fcfeb1217fe79f19da5",
         "type": "github"
       },
       "original": {
         "owner": "Bootstrap-Academy",
         "repo": "events-ms",
-        "rev": "337d3002183c7420a1ebd2bb38474350c36eb7cb",
+        "rev": "ff767ea8f76a253995b53fcfeb1217fe79f19da5",
         "type": "github"
       }
     },
@@ -1908,17 +1908,17 @@
         "poetry2nix": "poetry2nix_5"
       },
       "locked": {
-        "lastModified": 1789137387,
-        "narHash": "sha256-igngc+TwhxEBN6raGG25FNs8RmHesJrTSP4jOMxqhto=",
+        "lastModified": 1789201918,
+        "narHash": "sha256-wOau9cyHLxt/ZuZtFd3aryO7j57wPODkipIwJ45s3gs=",
         "owner": "Bootstrap-Academy",
         "repo": "skills-ms",
-        "rev": "7561f9b709746c273bee5717c18953d53e29faf4",
+        "rev": "7d083605655802d32f44e6fefb714ea0d177201a",
         "type": "github"
       },
       "original": {
         "owner": "Bootstrap-Academy",
         "repo": "skills-ms",
-        "rev": "7561f9b709746c273bee5717c18953d53e29faf4",
+        "rev": "7d083605655802d32f44e6fefb714ea0d177201a",
         "type": "github"
       }
     },
@@ -1928,17 +1928,17 @@
         "poetry2nix": "poetry2nix_6"
       },
       "locked": {
-        "lastModified": 1789137387,
-        "narHash": "sha256-igngc+TwhxEBN6raGG25FNs8RmHesJrTSP4jOMxqhto=",
+        "lastModified": 1789201918,
+        "narHash": "sha256-wOau9cyHLxt/ZuZtFd3aryO7j57wPODkipIwJ45s3gs=",
         "owner": "Bootstrap-Academy",
         "repo": "skills-ms",
-        "rev": "7561f9b709746c273bee5717c18953d53e29faf4",
+        "rev": "7d083605655802d32f44e6fefb714ea0d177201a",
         "type": "github"
       },
       "original": {
         "owner": "Bootstrap-Academy",
         "repo": "skills-ms",
-        "rev": "7561f9b709746c273bee5717c18953d53e29faf4",
+        "rev": "7d083605655802d32f44e6fefb714ea0d177201a",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -7,17 +7,17 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1789201767,
-        "narHash": "sha256-xZVjaZ+arskvj4sE3elPCTjqY8C1USic/t4nJcuGOZ4=",
+        "lastModified": 1789203310,
+        "narHash": "sha256-bbhAWV6LBTmCmSvsRerI7EyoJ7RFcVB5ROJXaX9igjE=",
         "owner": "Bootstrap-Academy",
         "repo": "backend",
-        "rev": "56e8b849d4b45e27d4495e89f524ed22d75cf49a",
+        "rev": "fc0b82a5d1ce09eebd4cb77f8fe2220e943aeb90",
         "type": "github"
       },
       "original": {
         "owner": "Bootstrap-Academy",
         "repo": "backend",
-        "rev": "56e8b849d4b45e27d4495e89f524ed22d75cf49a",
+        "rev": "fc0b82a5d1ce09eebd4cb77f8fe2220e943aeb90",
         "type": "github"
       }
     },
@@ -28,17 +28,17 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1789201767,
-        "narHash": "sha256-xZVjaZ+arskvj4sE3elPCTjqY8C1USic/t4nJcuGOZ4=",
+        "lastModified": 1789203310,
+        "narHash": "sha256-bbhAWV6LBTmCmSvsRerI7EyoJ7RFcVB5ROJXaX9igjE=",
         "owner": "Bootstrap-Academy",
         "repo": "backend",
-        "rev": "56e8b849d4b45e27d4495e89f524ed22d75cf49a",
+        "rev": "fc0b82a5d1ce09eebd4cb77f8fe2220e943aeb90",
         "type": "github"
       },
       "original": {
         "owner": "Bootstrap-Academy",
         "repo": "backend",
-        "rev": "56e8b849d4b45e27d4495e89f524ed22d75cf49a",
+        "rev": "fc0b82a5d1ce09eebd4cb77f8fe2220e943aeb90",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -17,13 +17,13 @@
     jobs-ms.url = "github:Bootstrap-Academy/jobs-ms/ea946c12f6f2caaa56e4b2e4edc73ce926ccfa2b";
     events-ms.url = "github:Bootstrap-Academy/events-ms/ff767ea8f76a253995b53fcfeb1217fe79f19da5";
     challenges-ms.url = "github:Bootstrap-Academy/challenges-ms/fcc9f52e568d322712a77552d404fab32fb1894c";
-    backend.url = "github:Bootstrap-Academy/backend/56e8b849d4b45e27d4495e89f524ed22d75cf49a";
+    backend.url = "github:Bootstrap-Academy/backend/fc0b82a5d1ce09eebd4cb77f8fe2220e943aeb90";
 
     skills-ms-develop.url = "github:Bootstrap-Academy/skills-ms/7d083605655802d32f44e6fefb714ea0d177201a";
     jobs-ms-develop.url = "github:Bootstrap-Academy/jobs-ms/ea946c12f6f2caaa56e4b2e4edc73ce926ccfa2b";
     events-ms-develop.url = "github:Bootstrap-Academy/events-ms/ff767ea8f76a253995b53fcfeb1217fe79f19da5";
     challenges-ms-develop.url = "github:Bootstrap-Academy/challenges-ms/fcc9f52e568d322712a77552d404fab32fb1894c";
-    backend-develop.url = "github:Bootstrap-Academy/backend/56e8b849d4b45e27d4495e89f524ed22d75cf49a";
+    backend-develop.url = "github:Bootstrap-Academy/backend/fc0b82a5d1ce09eebd4cb77f8fe2220e943aeb90";
   };
 
   outputs =

--- a/flake.nix
+++ b/flake.nix
@@ -13,17 +13,17 @@
     impermanence.url = "github:nix-community/impermanence";
     sandkasten.url = "git+https://radicle.defelo.de/zKBbWZxz73j7BZMbutM7TMMT4v5K.git";
 
-    skills-ms.url = "github:Bootstrap-Academy/skills-ms/7561f9b709746c273bee5717c18953d53e29faf4";
+    skills-ms.url = "github:Bootstrap-Academy/skills-ms/7d083605655802d32f44e6fefb714ea0d177201a";
     jobs-ms.url = "github:Bootstrap-Academy/jobs-ms/ea946c12f6f2caaa56e4b2e4edc73ce926ccfa2b";
-    events-ms.url = "github:Bootstrap-Academy/events-ms/337d3002183c7420a1ebd2bb38474350c36eb7cb";
-    challenges-ms.url = "github:Bootstrap-Academy/challenges-ms/6c4a7453b970212c31639048d59baccd87220e29";
-    backend.url = "github:Bootstrap-Academy/backend/ba62852fc4d76f8a38c6ce99f46abbaba3714062";
+    events-ms.url = "github:Bootstrap-Academy/events-ms/ff767ea8f76a253995b53fcfeb1217fe79f19da5";
+    challenges-ms.url = "github:Bootstrap-Academy/challenges-ms/fcc9f52e568d322712a77552d404fab32fb1894c";
+    backend.url = "github:Bootstrap-Academy/backend/56e8b849d4b45e27d4495e89f524ed22d75cf49a";
 
-    skills-ms-develop.url = "github:Bootstrap-Academy/skills-ms/7561f9b709746c273bee5717c18953d53e29faf4";
+    skills-ms-develop.url = "github:Bootstrap-Academy/skills-ms/7d083605655802d32f44e6fefb714ea0d177201a";
     jobs-ms-develop.url = "github:Bootstrap-Academy/jobs-ms/ea946c12f6f2caaa56e4b2e4edc73ce926ccfa2b";
-    events-ms-develop.url = "github:Bootstrap-Academy/events-ms/337d3002183c7420a1ebd2bb38474350c36eb7cb";
-    challenges-ms-develop.url = "github:Bootstrap-Academy/challenges-ms/6c4a7453b970212c31639048d59baccd87220e29";
-    backend-develop.url = "github:Bootstrap-Academy/backend/ba62852fc4d76f8a38c6ce99f46abbaba3714062";
+    events-ms-develop.url = "github:Bootstrap-Academy/events-ms/ff767ea8f76a253995b53fcfeb1217fe79f19da5";
+    challenges-ms-develop.url = "github:Bootstrap-Academy/challenges-ms/fcc9f52e568d322712a77552d404fab32fb1894c";
+    backend-develop.url = "github:Bootstrap-Academy/backend/56e8b849d4b45e27d4495e89f524ed22d75cf49a";
   };
 
   outputs =

--- a/hosts/prod/backend/default.nix
+++ b/hosts/prod/backend/default.nix
@@ -100,6 +100,7 @@ in
   # old backend
   academy.backend = {
     enable = true;
+    feedback.enable = true;
     name = "Bootstrap Academy Production Instance";
     domain = "api.bootstrap.academy";
     frontend = "https://bootstrap.academy";

--- a/hosts/prod/secrets.yml
+++ b/hosts/prod/secrets.yml
@@ -38,6 +38,7 @@ academy-backend:
         calendar-secret: ENC[AES256_GCM,data:G8xgwirRmQbuu94/NWg8ZCjSE5nDP99DDXYxA77LGUg9CcUs0rnNOGdw2Bc5d7I4O5ueAFnXr9fyZuw289u9fQ==,iv:76R0wCTQu59t8b9epVRY1u3ZvUjGgc+eIls+BPL2YJg=,tag:hHMn/61dqmtWHxI779n0cg==,type:str]
     challenges-ms:
         sentry-dsn: ENC[AES256_GCM,data:Uev2RpQX35dxSWk2h1odDOIh0V3Op5icKVC/zL0uSSWQdnG3rWBQnjZoVvv/o9A/PFC5gsOY76I6YVhwnNF+XmX6o7lwsQk=,iv:UuaEqqtnNJ8H4x3wpmzrtB2N34F7+EWIHwLY0dn2wm8=,tag:Y8SvervNSJxdJmUwKioYyg==,type:str]
+    feedback-github-token: ENC[AES256_GCM,data:RYVZzf/15j30kfUAk2gBFQj1LOCHVB0WC5LyqwuhNv/rQ4pe8vHn+A==,iv:T1t0O30ZmPZJGLlKPBJPOh24NrL82mHYL66YjMjz8pM=,tag:eLCJ8PLcO6cSCad2Rkn2Rg==,type:str]
 backup:
     box:
         repository-password: ENC[AES256_GCM,data:irNRNu1175EmwRRcX4oEsKcAsxZmbe7apzfFHq3L9L/ni+yJ4jLj48ZsriK+/chQ4DIwrN/hd8ae8MlIp61cNaXrwm7JXaGvtscLcYW05ARPR8grP2BmOc4gXsbF3j9NWQIrHSTHkiPPc6wyP5Rz5FmuRQRB83fPTALpjnChFcE=,iv:LBTQE/BTCVkKIriA+st6ak0zalKiiBCBWONyzaSVAN8=,tag:j/8sOUh4jcfI0jhaRdQR0w==,type:str]
@@ -111,8 +112,8 @@ sops:
             /XbLomJwsxKw13cfsE6LU97KmWW+R/yI2ruB9wnSMFWQTS8zINmTxg==
             -----END AGE ENCRYPTED FILE-----
           recipient: age13r2hmarqllghyaavnu57w8rtcsf5qgnvr65smw50fkd2c4gvrgfshhwj3n
-    lastmodified: "2026-08-10T19:56:20Z"
-    mac: ENC[AES256_GCM,data:khhaTiPsZzPCwafiTigjkM6GFx99l1cgb/XmDI/34wRsKq2BEYa9sFioeBdvmQ3e4x399dhhHKXCBEXUvxgIv4on9v8Q+YIM6pU158079e5eit+XwDnvNj97YevtbdDMar5Noy9QQO8+KdxkyTQ2e2Cu05pN8ScRRNxc01H793w=,iv:4BbRxBPOVBkERnDH2/S0ZynMXYs5ae6SzT/nQO3Brhw=,tag:/PcSUAav32XAl/qWQiLpsg==,type:str]
+    lastmodified: "2026-09-12T06:12:36Z"
+    mac: ENC[AES256_GCM,data:0/kgm6cn48+OxjZJH/rJQUBfkHghtoI5z7k2YJYKb14PLx6KU4m/PT3HWjSjIclsoSdCjnrwc9OF2oHDnCLFVhjxyNQ7x5F1IhmY1xqjLG9L12ubxYon/MksPu2h7eH2yhfZ5PsZ9jvzT2F+8HBpz5xCO8yyI6N4tl2xNnC4hyw=,iv:yuGAaoLUUMq6bZwKgGAZ+nA/ytdHvs9Xrrfr76Hb+Y8=,tag:NoLKLblGmSyeoVPqYl1gLg==,type:str]
     pgp:
         - created_at: "2026-09-07T13:51:35Z"
           enc: |-

--- a/hosts/test/backend/default.nix
+++ b/hosts/test/backend/default.nix
@@ -105,6 +105,7 @@ in
   # old backend
   academy.backend = {
     enable = true;
+    feedback.enable = true;
     name = "Bootstrap Academy Test Instance";
     domain = "api.test.bootstrap.academy";
     frontend = "https://test.bootstrap.academy";

--- a/hosts/test/secrets.yml
+++ b/hosts/test/secrets.yml
@@ -23,6 +23,7 @@ academy-backend:
         calendar-secret: ENC[AES256_GCM,data:biWFoxU//WtYoowGuFWKMsGBj/Ivc49bkovaeLeZLsc9s72D1R5/eLRWQaZufuaXv6B2z89fSL9eLLVVIeHm3w==,iv:1cREK9F0agwACgB7oY9zoLhsjSn+FUcWmalMRExxcE4=,tag:k/Ay/UVy7WUcVkDxJvsqoQ==,type:str]
     challenges-ms:
         sentry-dsn: ENC[AES256_GCM,data:5+OhV9JfJwT12ujupUnAnqdQ015/Me7AgP6lH5QyddcVhLYJ1e8Ut4q6dLhBslAc4MPVVBO4LPGlKKqHSImej1pTNjNxOA==,iv:Tp2WVkc7nO/jJkwN1ZsLVw/h850iWIKnf5Svm1VNEq8=,tag:e20MPnLtz6/Fzc1u28BP/Q==,type:str]
+    feedback-github-token: ENC[AES256_GCM,data:WFZzGYGda69dr6iezTGeK4OCRj1IboAdi8VOyRAGMZ+D8VXPCw8LvA==,iv:ZTQ9cUeuC9KWuttrqaRT4Q+Y9EVZa9yIi6F7IpfbP6A=,tag:Va2InjkPBPwJKL033NAD5g==,type:str]
 ssh:
     private-key: ENC[AES256_GCM,data:O10JfLuTeLzHv7w9qy39n8w2sJDPpWj8D9oCOi0Sfkg2JOa6Xo1XjZFskHt+mqfzDAx38trqdfSLzq2+HSPQiXXN2H2y9F1e4xtROsbuTGINBYSm17SdJ5qJ20VnIbWNZFB6MzXcUsiVscey+DIYas9/t4nPZTI6snw0N3LW7TWowdo3IH96Ne61uCnyH4JjGHSATDIRRR97EwNufMTGRZtqlzZM/lDPjUUplehf7FLokjSyDcq+R2eOBSLclBejpE13oK+NzKx/eHtQctXKzVRMgPVUwjxob8oSAIWO233wLzd/t6HsB1GwiZn0U4jDNQM0oOfLlOGHBTH1cSWKNiPYDdPmMGVuwYbLe1uA5c2pkP40s0c7V8gK1xSjlLb8fKtRsQjDTWK0jApCD/1xIDN5ZytToZ6VxSs90CBLUEAV81Ta5oaNYauedkc11SG9+yTZRUw0D2VQpFOVSecLyIYj9u9Sk+/7tr/++OF78zwzk9leVFmydDl1dcPSTi4hzUrk,iv:2owaBkw3yIpLw/L3n6qAS/sYEqj/fsxbyLYsmy5B3OM=,tag:LcR/AuT0x4bLby9SSaaKBw==,type:str]
 backup:
@@ -88,8 +89,8 @@ sops:
             dg/NR5uZKlH8FKkhAqOc41b89QjFtpGS8SoxJLaQsHeiUL476kgtTA==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1l0u9h7wjsdge789f4fuj0ya0cz5y6c9m7nqhlhactwlzg7rt4fxquvqdzy
-    lastmodified: "2026-01-25T14:15:58Z"
-    mac: ENC[AES256_GCM,data:zylS/5NTJg7U7jiG12a6murm8g9YkgvytneNgGCLI/0QsYkvHWoOkXSMzKsmGfYAsIttWXe5YkkjQzMTfE9ZSKUGISM4vkw1pUmBynRYzNFL7IQDg4wlMEuqGjJaf1om22CMYm1n5Hd73QkUXX3htT+CEHwzsWrTj8uivR3uhNY=,iv:FCsB5fG5u4Bfj7l6WHZfpjThSEXrrwsnb8nud8p5KSk=,tag:mr5LDtbgJ6WQdQTSPUp0bg==,type:str]
+    lastmodified: "2026-09-12T06:12:36Z"
+    mac: ENC[AES256_GCM,data:DOQsPqXl6oNq7XxN4aJiRAv/eUWc7NOkCyaGkRkA3yo+wcqd4QnYUutUZW6MOxjsX8e00MiiLWO9vhejIb8w1dMJzbuvZEaM5G3zOtRHcF9Wo/s1vVf5Hxg5T0kLkQxHwRNPMGm/nqpy+wA2MUWfWHCGuhfVNZL5cHW2B4KgDqs=,iv:lBDx3JG7ekuhNsd96HsPnNf66KKwBLMkkwdUMHBCRnI=,tag:GwMLvj2/fTBKtpqNGi5zLg==,type:str]
     pgp:
         - created_at: "2026-09-07T13:51:34Z"
           enc: |-

--- a/modules/backend/default.nix
+++ b/modules/backend/default.nix
@@ -1,5 +1,6 @@
 { lib, ... }: {
   imports = [
+    ./feedback.nix
     ./internal-jwt-secrets.nix
     ./nginx.nix
     ./postgresql.nix

--- a/modules/backend/feedback.nix
+++ b/modules/backend/feedback.nix
@@ -1,0 +1,34 @@
+{ config, lib, ... }:
+
+let
+  cfg = config.academy.backend;
+in
+{
+  options.academy.backend.feedback.enable = lib.mkEnableOption "public GitHub feedback";
+
+  config = lib.mkIf (cfg.enable && cfg.feedback.enable) {
+    services.academy.backend.settings.feedback = {
+      enabled = true;
+      github_token_file = config.sops.secrets."academy-backend/feedback-github-token".path;
+      # academy-backend's StateDirectory owns this writable directory. Both
+      # application hosts already persist /var/lib/academy across reboots.
+      storage_path = "/var/lib/academy/feedback";
+      public_base_url = "https://${cfg.domain}";
+    };
+
+    sops.secrets."academy-backend/feedback-github-token" = {
+      path = "/run/secrets/feedback-github-token";
+      owner = "academy";
+      group = "academy";
+      mode = "0400";
+      restartUnits = [ "academy-backend.service" ];
+    };
+
+    # Keep the larger screenshot envelope scoped to this endpoint. Image
+    # decoding, pixel limits and the JSON limit are also enforced by the API.
+    services.nginx.virtualHosts.${cfg.domain}.locations."= /feedback" = {
+      proxyPass = "http://127.0.0.1:8000";
+      extraConfig = "client_max_body_size 5m;";
+    };
+  };
+}

--- a/modules/backend/feedback.nix
+++ b/modules/backend/feedback.nix
@@ -1,34 +1,54 @@
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  options,
+  ...
+}:
 
 let
   cfg = config.academy.backend;
+  backendAvailable = options ? services.academy.backend.enable;
 in
 {
   options.academy.backend.feedback.enable = lib.mkEnableOption "public GitHub feedback";
 
-  config = lib.mkIf (cfg.enable && cfg.feedback.enable) {
-    services.academy.backend.settings.feedback = {
-      enabled = true;
-      github_token_file = config.sops.secrets."academy-backend/feedback-github-token".path;
-      # academy-backend's StateDirectory owns this writable directory. Both
-      # application hosts already persist /var/lib/academy across reboots.
-      storage_path = "/var/lib/academy/feedback";
-      public_base_url = "https://${cfg.domain}";
-    };
+  config = lib.mkMerge [
+    {
+      assertions = [
+        {
+          assertion = cfg.feedback.enable -> (cfg.enable && backendAvailable);
+          message = "Feedback requires academy.backend.enable and the backend NixOS module.";
+        }
+      ];
+    }
+    # Hosts without the backend module have no services.academy options. Avoid
+    # defining that namespace there, even under a false mkIf condition.
+    (lib.mkIf (cfg.enable && cfg.feedback.enable) (
+      lib.optionalAttrs backendAvailable {
+        services.academy.backend.settings.feedback = {
+          enabled = true;
+          github_token_file = config.sops.secrets."academy-backend/feedback-github-token".path;
+          # academy-backend's StateDirectory owns this writable directory. Both
+          # application hosts already persist /var/lib/academy across reboots.
+          storage_path = "/var/lib/academy/feedback";
+          public_base_url = "https://${cfg.domain}";
+        };
 
-    sops.secrets."academy-backend/feedback-github-token" = {
-      path = "/run/secrets/feedback-github-token";
-      owner = "academy";
-      group = "academy";
-      mode = "0400";
-      restartUnits = [ "academy-backend.service" ];
-    };
+        sops.secrets."academy-backend/feedback-github-token" = {
+          path = "/run/secrets/feedback-github-token";
+          owner = "academy";
+          group = "academy";
+          mode = "0400";
+          restartUnits = [ "academy-backend.service" ];
+        };
 
-    # Keep the larger screenshot envelope scoped to this endpoint. Image
-    # decoding, pixel limits and the JSON limit are also enforced by the API.
-    services.nginx.virtualHosts.${cfg.domain}.locations."= /feedback" = {
-      proxyPass = "http://127.0.0.1:8000";
-      extraConfig = "client_max_body_size 5m;";
-    };
-  };
+        # Keep the larger screenshot envelope scoped to this endpoint. Image
+        # decoding, pixel limits and the JSON limit are also enforced by the API.
+        services.nginx.virtualHosts.${cfg.domain}.locations."= /feedback" = {
+          proxyPass = "http://127.0.0.1:8000";
+          extraConfig = "client_max_body_size 5m;";
+        };
+      }
+    ))
+  ];
 }


### PR DESCRIPTION
Enable the public feedback endpoint on both hosts with a SOPS-encrypted runtime GitHub credential, bounded persistent storage and the reviewed backend/Challenges mail protection. Pin the reviewed customer-text updates in Backend, Challenges, Events and Skills. Preserve the existing course-store dependency, Jobs and unrelated secrets/settings.

Validation: both normal host systems and two temporary held variants built successfully; each held unit tree differs only by six explicit writer conditions. All four closure graphs contain 85 courses. The signed commit is checked against the same tree and final derivations before activation. Native forward migrations require stopping old writers first, verifying both guards while held, and testing real GitHub delivery in the test environment before production. Recovery must retain the new migration registry and email protection.
