### PR TITLE
Enable curated learning rooms in the Skills service

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1908,17 +1908,17 @@
         "poetry2nix": "poetry2nix_5"
       },
       "locked": {
-        "lastModified": 1789201918,
-        "narHash": "sha256-wOau9cyHLxt/ZuZtFd3aryO7j57wPODkipIwJ45s3gs=",
+        "lastModified": 1789223362,
+        "narHash": "sha256-oQYyQm17ayFd/eQYaHIk2YfmBOCRCxmVCWYkdvdfArs=",
         "owner": "Bootstrap-Academy",
         "repo": "skills-ms",
-        "rev": "7d083605655802d32f44e6fefb714ea0d177201a",
+        "rev": "348c4b39407fcf9334aa5efd803bbcbe06a415f9",
         "type": "github"
       },
       "original": {
         "owner": "Bootstrap-Academy",
         "repo": "skills-ms",
-        "rev": "7d083605655802d32f44e6fefb714ea0d177201a",
+        "rev": "348c4b39407fcf9334aa5efd803bbcbe06a415f9",
         "type": "github"
       }
     },
@@ -1928,17 +1928,17 @@
         "poetry2nix": "poetry2nix_6"
       },
       "locked": {
-        "lastModified": 1789201918,
-        "narHash": "sha256-wOau9cyHLxt/ZuZtFd3aryO7j57wPODkipIwJ45s3gs=",
+        "lastModified": 1789223362,
+        "narHash": "sha256-oQYyQm17ayFd/eQYaHIk2YfmBOCRCxmVCWYkdvdfArs=",
         "owner": "Bootstrap-Academy",
         "repo": "skills-ms",
-        "rev": "7d083605655802d32f44e6fefb714ea0d177201a",
+        "rev": "348c4b39407fcf9334aa5efd803bbcbe06a415f9",
         "type": "github"
       },
       "original": {
         "owner": "Bootstrap-Academy",
         "repo": "skills-ms",
-        "rev": "7d083605655802d32f44e6fefb714ea0d177201a",
+        "rev": "348c4b39407fcf9334aa5efd803bbcbe06a415f9",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -13,13 +13,13 @@
     impermanence.url = "github:nix-community/impermanence";
     sandkasten.url = "git+https://radicle.defelo.de/zKBbWZxz73j7BZMbutM7TMMT4v5K.git";
 
-    skills-ms.url = "github:Bootstrap-Academy/skills-ms/7d083605655802d32f44e6fefb714ea0d177201a";
+    skills-ms.url = "github:Bootstrap-Academy/skills-ms/348c4b39407fcf9334aa5efd803bbcbe06a415f9";
     jobs-ms.url = "github:Bootstrap-Academy/jobs-ms/ea946c12f6f2caaa56e4b2e4edc73ce926ccfa2b";
     events-ms.url = "github:Bootstrap-Academy/events-ms/ff767ea8f76a253995b53fcfeb1217fe79f19da5";
     challenges-ms.url = "github:Bootstrap-Academy/challenges-ms/fcc9f52e568d322712a77552d404fab32fb1894c";
     backend.url = "github:Bootstrap-Academy/backend/fc0b82a5d1ce09eebd4cb77f8fe2220e943aeb90";
 
-    skills-ms-develop.url = "github:Bootstrap-Academy/skills-ms/7d083605655802d32f44e6fefb714ea0d177201a";
+    skills-ms-develop.url = "github:Bootstrap-Academy/skills-ms/348c4b39407fcf9334aa5efd803bbcbe06a415f9";
     jobs-ms-develop.url = "github:Bootstrap-Academy/jobs-ms/ea946c12f6f2caaa56e4b2e4edc73ce926ccfa2b";
     events-ms-develop.url = "github:Bootstrap-Academy/events-ms/ff767ea8f76a253995b53fcfeb1217fe79f19da5";
     challenges-ms-develop.url = "github:Bootstrap-Academy/challenges-ms/fcc9f52e568d322712a77552d404fab32fb1894c";

--- a/hosts/prod/backend/skills.nix
+++ b/hosts/prod/backend/skills.nix
@@ -58,6 +58,26 @@ in
 
       COURSES = "${skills-ms.packages.${system}.courses}";
 
+      ROOMS_ENABLED = "true";
+      CHALLENGES_URL = "http://127.0.0.1:8005";
+      LEARNING_ROOMS_EXERCISE_REFS = builtins.toJSON {
+        loops-predict = {
+          type = "multiple_choice";
+          task_id = "ddf71be4-f432-46d5-9cf1-f87e04e4d312";
+          subtask_id = "51f75114-b718-451d-a2f9-796376661280";
+        };
+        loops-match = {
+          type = "matching";
+          task_id = "ddf71be4-f432-46d5-9cf1-f87e04e4d312";
+          subtask_id = "f3c393d7-8c1c-4151-8322-94cc0607d892";
+        };
+        loops-code = {
+          type = "coding";
+          task_id = "ddf71be4-f432-46d5-9cf1-f87e04e4d312";
+          subtask_id = "9e4572bf-5d0a-4f68-80aa-38a837d556e0";
+        };
+      };
+
       LECTURE_XP = "10";
       MP4_LECTURES = "/mnt/lectures";
       STREAM_CHUNK_SIZE = toString (4 * 1024 * 1024); # bytes

--- a/hosts/test/backend/skills.nix
+++ b/hosts/test/backend/skills.nix
@@ -58,6 +58,26 @@ in
 
       COURSES = "${skills-ms-develop.packages.${system}.courses}";
 
+      ROOMS_ENABLED = "true";
+      CHALLENGES_URL = "http://127.0.0.1:8005";
+      LEARNING_ROOMS_EXERCISE_REFS = builtins.toJSON {
+        loops-predict = {
+          type = "multiple_choice";
+          task_id = "94338c50-72dd-4c33-8f29-0e50bd33f328";
+          subtask_id = "5184dd0b-8880-410a-ae18-34b2c014f70c";
+        };
+        loops-match = {
+          type = "matching";
+          task_id = "94338c50-72dd-4c33-8f29-0e50bd33f328";
+          subtask_id = "5bcb585f-302b-4265-b2f5-4a255f872394";
+        };
+        loops-code = {
+          type = "coding";
+          task_id = "94338c50-72dd-4c33-8f29-0e50bd33f328";
+          subtask_id = "753c85ca-caf4-41fd-a927-2925fc73b649";
+        };
+      };
+
       LECTURE_XP = "10";
       MP4_LECTURES = "/mnt/lectures";
       STREAM_CHUNK_SIZE = toString (4 * 1024 * 1024); # bytes


### PR DESCRIPTION
Enable the first curated learning rooms in the Skills service on Test and production, using the same reviewed package and separate references to exercises created in each environment. Existing courses, challenge grading, payments and other service pins are preserved.

Only the two Skills inputs and their host settings change. Local builds for both hosts reproduce the currently active baselines and change only the Skills service, its erasure-sweep service and derived system paths. Both retain the same 85-course store path and unchanged SMTP settings. Matching recovery closures use the new migration runner with rooms disabled, retaining private learner state.

Validation: Skills PR407 passed all six CI checks, 211 backend tests and packaged catalogue checks. A browser completed introductions and real Test quiz, matching and Python submissions, including persistence after reload and narrow-screen layouts. Host-specific deployment, native migration and fresh runtime checks are recorded separately; other services and mail counters are checked before and after activation.
